### PR TITLE
Add SaveException when model saving fails

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -48,7 +48,10 @@ class FactoryMuff
     {
         $obj = $this->instance( $model, $attr );
 
-        $obj->save();
+        $result = $obj->save();
+        if ( !$result ) {
+            throw new SaveException('Could not save the model of type: '.$model);
+        }
 
         return $obj;
     }

--- a/src/Zizaco/FactoryMuff/SaveException.php
+++ b/src/Zizaco/FactoryMuff/SaveException.php
@@ -1,0 +1,6 @@
+<?php namespace Zizaco\FactoryMuff;
+
+class SaveException extends \Exception
+{
+
+}

--- a/tests/FactoryMuffTest.php
+++ b/tests/FactoryMuffTest.php
@@ -28,6 +28,12 @@ class FactoryMuffTest extends PHPUnit_Framework_TestCase {
         
         $this->assertTrue( is_numeric($obj->id) );
     }
+
+    public function test_should_throw_exception_on_model_save_failure()
+    {
+        $this->setExpectedException('\Zizaco\FactoryMuff\SaveException');
+        $obj = $this->factory->create('SampleModelC');
+    }
 }
 
 /**
@@ -66,4 +72,24 @@ class SampleModelB extends SampleModelA
         'email' => 'email',
         'content' => 'text',
     );
+}
+
+
+/**
+* Testing only
+*
+*/
+class SampleModelC
+{
+    // Array that determines the kind of attributes
+    // you would like to have
+    public static $factory = array(
+    );
+
+    // Eloquent models return False on save failure.
+    // We *might* want to throw exceptions in that case.
+    public function save()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
particularly useful when using model validation as with Ardent.

Currently there is no indication whatsoever that the models created by FactoryMuff failed to be saved, which makes for no-fun-whatsoever.

For example, I was using FactoryMuff to test a Confide user system, and the creation of Users with Factory Muff was silently failing because my factory rules did not account for the "confirmation" required on the password field.

I appreciate this specific example may be something to do with me getting the factory rules wrong, or not knowing how to mimic the "confirmation" directive in Ardent, but in any case I think this would be a very useful feature, since I believe it's safe to assume you really do want all models created with Factory Muff to successfully save.
