### PR TITLE
Fixes bug where SaveException is never thrown

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -53,14 +53,12 @@ class FactoryMuff
 
             $message = '';
 
-            if($obj->errors)
+            if(isset($obj->validationErrors)) 
             {
-                $message = $obj->errors.' - ';
-            }
-
-            if($obj->error)
-            {
-                $message = $obj->error.' - ';
+                if($obj->validationErrors)
+                {
+                    $message = $obj->validationErrors.' - ';
+                }
             }
 
             throw new SaveException($message.'Could not save the model of type: '.$model);


### PR DESCRIPTION
Fixes bug introduced in Travis Build #30.
https://travis-ci.org/Zizaco/factory-muff/builds/7442116

I was receiving this error when Ardent validations failed:
PHP Fatal error:  Call to undefined method Illuminate\Support\MessageBag::getResults()

If the model failed to save, create() was trying to access an unknown class attribute (errors) before throwing SaveException.  

I was unsure of the original purpose as I can't find an errors attribute anywhere in Eloquent. Ardent has a validationErrors attribute-- this PR first checks for its existence before formatting and passing to SaveException.
