### PR TITLE
Fixes bug where Exception isn't found in current namespace

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -193,7 +193,7 @@ class FactoryMuff
                 $return = call_user_func_array("$model::$callable", $params);
                 return $return;
             } else {
-                throw new Exception("$model does not have a static $callable method");
+                throw new \Exception("$model does not have a static $callable method");
             }
         }
 


### PR DESCRIPTION
This properly namespaces the Exception class as it doesn't exist under Zizaco\FactoryMuff. This was throwing an error when trying to be used.
