### PR TITLE
Use mt_rand to pick a random word instead of popping from array

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -204,13 +204,15 @@ class FactoryMuff
         // Pick a word and append a domain
         case 'email':
             shuffle( $this->mail_domains );
-            $result = array_pop( $this->wordlist ).'@'.$this->mail_domains[0];
+            $k = mt_rand(0, count($this->wordlist) - 1);
+            $result = $this->wordlist[$k].'@'.$this->mail_domains[0];
             break;
 
         // Pick some words
         case 'text':
             for ( $i=0; $i < ( ((int)date( 'U' )+rand(0,5)) % 8 ) + 2; $i++ ) {
-                $result .= array_pop( $this->wordlist )." ";
+                $k = mt_rand(0, count($this->wordlist) - 1);
+                $result .= $this->wordlist[$k]." ";
             }
 
             $result = trim( $result );
@@ -218,7 +220,8 @@ class FactoryMuff
 
         // Pick a single word then
         case 'string':
-            $result = array_pop( $this->wordlist );
+            $k = mt_rand(0, count($this->wordlist) - 1);
+            $result = $this->wordlist[$k];
 
             if (rand(0,1))
                 $result = ucfirst($result);


### PR DESCRIPTION
We use an in-memory sqllite database to test our database models. When using FactoryMuff I quickly go through the wordlist as we migrate up / tear down the database for each new test. Some tests run long enough that I run into null values as wordlist is empty, and my tests fail.

I found it a more novel solution to simply randomize the words, instead of removing them from the array, as this protects against hitting a hard limit of the wordlist. 

As it's purely dummy data, I can't think of a situation where someone would expect or rely on FactoryMuff to generate unique values.
