### PR TITLE
Fixes bug where null words are sometimes created

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -106,12 +106,6 @@ class FactoryMuff
      */
     public function attributesFor( $model, $attr = array() )
     {
-        // Prepare word list if empty
-        if ( count( $this->wordlist ) == 0 ) {
-            $this->wordlist = include(__DIR__.'/Wordlist.php');
-            shuffle( $this->wordlist );
-        }
-
         // Get the $factory static and check for errors
         $static_vars = get_class_vars( $model );
 
@@ -204,13 +198,14 @@ class FactoryMuff
         // Pick a word and append a domain
         case 'email':
             shuffle( $this->mail_domains );
-            $result = array_pop( $this->wordlist ).'@'.$this->mail_domains[0];
+
+            $result = $this->getWord().'@'.$this->mail_domains[0];
             break;
 
         // Pick some words
         case 'text':
             for ( $i=0; $i < ( ((int)date( 'U' )+rand(0,5)) % 8 ) + 2; $i++ ) {
-                $result .= array_pop( $this->wordlist )." ";
+                $result .= $this->getWord()." ";
             }
 
             $result = trim( $result );
@@ -218,7 +213,7 @@ class FactoryMuff
 
         // Pick a single word then
         case 'string':
-            $result = array_pop( $this->wordlist );
+            $result = $this->getWord();
 
             if (rand(0,1))
                 $result = ucfirst($result);
@@ -237,5 +232,15 @@ class FactoryMuff
         }
 
         return $result;
+    }
+
+    public function getWord() {
+        // Reset wordlist if empty
+        if ( count( $this->wordlist ) == 0 ) {
+            $this->wordlist = include(__DIR__.'/Wordlist.php');
+            shuffle( $this->wordlist );
+        }
+
+        return array_pop($this->wordlist);
     }
 }

--- a/tests/FactoryMuffTest.php
+++ b/tests/FactoryMuffTest.php
@@ -56,6 +56,12 @@ class FactoryMuffTest extends PHPUnit_Framework_TestCase {
 
         $this->assertRegExp('|^[a-z0-9]+$|', $obj->munged_model);
     }
+    public function test_should_get_word()
+    {
+        $str = $this->factory->getWord();
+
+        $this->assertNotNull($str);
+    }
 }
 
 /**


### PR DESCRIPTION
I encountered some instances where I hit the end of wordlist before attributesFor() was called to reset it. This happens if count($static_vars['factory']) > count($this->wordlist) when count($this->wordlist) != 0 and $static_vars['factory'] doesn't contain additional factories that would cause attributesFor to fire. 

For example, if there are 2 words left in the wordlist, the wordlist won't get reset as count() != 0, and if the current $factory array has 3 words, on the 3rd word a null value will be generated.

This change moves that responsibility of fetching a word to a getWord method, which always checks for count of wordlist before using it.
