### PR TITLE
New integer attribute and fixed typos

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -191,6 +191,14 @@ class FactoryMuff
             }
         }
 
+        if ( is_string($kind) && substr( $kind, 0, 8 ) === 'integer|' ) {
+            $numgen = substr( $kind, 8 );
+
+            for ( $i=0; $i<$numgen; $i++ ) {
+                $result .= mt_rand(0,9);
+            }
+        }
+
         // Overwise interpret the kind and 'generate' some
         // crap.
         switch ( $kind ) {


### PR DESCRIPTION
Hi, this is my first fork so I hope all is well.

This push includes some spelling/grammatical changes made to the code.
It also contains a new attribute 'random integer' whereby the length of the integer can be specified e.g 'integer|4' will produce 6408
