### PR TITLE
Few fixes here (Urgent, current release wont work)

### DIFF
--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -235,7 +235,8 @@ class FactoryMuff
                 throw new \Exception("$model does not have a static $callable method");
             }
         }
-        elseif ( is_string($kind) && substr( $kind, 0, 8 ) === 'integer|' ) {
+        
+        else if ( is_string($kind) && substr( $kind, 0, 8 ) === 'integer|' ) {
             $numgen = substr( $kind, 8 );
 
             $result = null;


### PR DESCRIPTION
- Result needs set to null before appending numbers for "interger|"
- Switch case needs to be in an else statement, otherwise we reset $result back to $kind (default in switch)
