### PR TITLE
Add option to define factory as static method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ class Message extends Eloquent
     }
 ```
 
+You can also declare a static method named `factory()` on your model. This allows more flexibility as PHP has restrictions on what you can use as array values when defining properties.
+
+Example:
+```php
+class Message extends Eloquent
+{
+    // Defined as a static method
+    public static factory()
+    {
+        return array(
+            'user_id' => 'factory|User',
+            // Not possible when defined as a static array
+            'greeting' => RandomGreeting::get(),
+            // Closures will be called automatically
+            'four' => function() {
+                return 2 + 2;
+            },
+        );
+    }
+```
+
 To create model instances do the following:
 ```php
 <?php

--- a/src/Zizaco/FactoryMuff/FactoryMuff.php
+++ b/src/Zizaco/FactoryMuff/FactoryMuff.php
@@ -138,6 +138,11 @@ class FactoryMuff
         if(isset($this->factories[$model])) {
             return $this->factories[$model];
         }
+
+        if(method_exists($model, 'factory'))
+        {
+            return $model::factory();
+        }
         else {
             // Get the $factory static and check for errors
             $static_vars = get_class_vars( $model );
@@ -146,6 +151,7 @@ class FactoryMuff
                 return $static_vars['factory'];
             }
         }
+
         throw new NoDefinedFactoryException('Factory not defined for class: ' . $model);
     }
 

--- a/tests/FactoryMuffTest.php
+++ b/tests/FactoryMuffTest.php
@@ -163,6 +163,16 @@ class FactoryMuffTest extends PHPUnit_Framework_TestCase {
         $this->assertEquals('just a string', $obj->text);
 
     }
+
+    public function test_can_create_from_static_method()
+    {
+        $this->factory->create('ModelWithStaticMethodFactory');
+
+        $obj = $this->factory->create('ModelWithStaticMethodFactory');
+
+        $this->assertEquals('just a string', $obj->string);
+        $this->assertEquals(4, $obj->four);
+    }
 }
 
 /**
@@ -321,6 +331,24 @@ class SampleModel_id
 class SampleModel_null
 {
     public static $factory = array();
+
+    public function save()
+    {
+        return true;
+    }
+}
+
+class ModelWithStaticMethodFactory
+{
+    public static function factory()
+    {
+        return array(
+            'string' => 'just a string',
+            'four' => function() {
+                return 2 + 2;
+            }
+        );
+    }
 
     public function save()
     {


### PR DESCRIPTION
This lets you define a public static function named factory() on the model that will return the factory array.

This is related to #34 as it allows you to actually use closures / callables as values in the array.
