### PR TITLE
Conflict merge error.

### DIFF
--- a/src/Zizaco/FactoryMuff/Kind/Generic.php
+++ b/src/Zizaco/FactoryMuff/Kind/Generic.php
@@ -2,6 +2,7 @@
 
 namespace Zizaco\FactoryMuff\Kind;
 
+use InvalidArgumentException;
 use Zizaco\FactoryMuff\Kind;
 
 class Generic extends Kind

--- a/tests/FactoryMuffTest.php
+++ b/tests/FactoryMuffTest.php
@@ -167,6 +167,14 @@ class FactoryMuffTest extends PHPUnit_Framework_TestCase
         $obj = $this->factory->create('SampleModelA');
 
         $this->assertEquals('just a string', $obj->text);
+
+        $this->factory->define('SampleModelA', array(
+            'text' => 'sneakyString',
+        ));
+
+        $obj = $this->factory->create('SampleModelA');
+
+        $this->assertEquals('sneakyString', $obj->text);
     }
 
     public function test_faker_default_boolean()


### PR DESCRIPTION
A conflict merge error snuck by as the old test was hitting the early "Does it have spaces" guard clause, while the later "invalid argument" exception wasnt being caught correctly. 

Added a test to stop it happening.
