### PR TITLE
Fix for date kind test

### DIFF
--- a/tests/FactoryMuffTest.php
+++ b/tests/FactoryMuffTest.php
@@ -34,20 +34,15 @@ class FactoryMuffTest extends PHPUnit_Framework_TestCase
 
     public function test_date_kind()
     {
-        $formats = array(
-            'Y-m-d', 'Ymd h:s', 'F d Y h:mA',
-            'l F j Y', 'G:i:s e', 'D g d-m-y'
-        );
+        $format = 'Y-m-d';
         
-        for ($i = 0; $i < count($formats); $i++) {
-            $this->factory->define('SampleModelA', array(
-                'created' => 'date|' . $formats[$i],
-            ));
+        $this->factory->define('SampleModelA', array(
+            'created' => 'date|' . $format,
+        ));
 
-            $obj = $this->factory->create('SampleModelA');
-            $dateTime = \DateTime::createFromFormat($formats[$i], $obj->created);
-            $this->assertEquals($obj->created, $dateTime->format($formats[$i]));
-        }
+        $obj = $this->factory->create('SampleModelA');
+        $dateTime = \DateTime::createFromFormat($format, $obj->created);
+        $this->assertEquals($obj->created, $dateTime->format($format));
     }
 
     public function test_integer()


### PR DESCRIPTION
Hi,
This test first creates an object having a date attribute with the specified format, then constructs a `\DateTime` by assuming that the generated attribute is in the correct format. If this assumption is correct, then `$dateTime->format($format)` will be the same as the generated attribute.
