### PR TITLE
Testing Improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
   - hhvm
 
 before_script:
-  - curl -s http://getcomposer.org/installer | php
-  - php composer.phar install --dev
+  - travis_retry composer self-update
+  - travis_retry composer install --no-interaction --prefer-source --dev
 
-script: phpunit
+script:
+  - vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,9 @@
         "php": ">=5.3.0",
         "fzaninotto/faker" : "~1.3"
     },
+    "require-dev": {
+        "phpunit/phpunit": "~4.0"
+    },
     "autoload": {
         "psr-0": {
             "League\\FactoryMuffin": "src/"


### PR DESCRIPTION
Let's correctly specify phpunit as a dev-dependency and make sure travis tests on php 5.6. I've also updated the travis install script to ensure dependencies are installed correctly every time.
