### PR TITLE
Docblock and minor cs fixes

### DIFF
--- a/src/Facade/FactoryMuffin.php
+++ b/src/Facade/FactoryMuffin.php
@@ -22,13 +22,15 @@ class FactoryMuffin
     private static $fmInstance;
 
     /**
-     * Get or stance FactoryMuffin obj.
+     * Get the underline FactoryMuffin instance.
+     *
+     * We'll always cache the instance and reuse it.
      *
      * @return \League\FactoryMuffin\FactoryMuffin
      */
     private static function fmInstance()
     {
-        if (! static::$fmInstance) {
+        if (!static::$fmInstance) {
             static::$fmInstance = new \League\FactoryMuffin\FactoryMuffin;
         }
 
@@ -41,7 +43,7 @@ class FactoryMuffin
      * @param string $model Model class name.
      * @param array  $attr  Model attributes.
      *
-     * @return mixed Returns the model instance.
+     * @return object
      */
     public static function create($model, $attr = array())
     {
@@ -67,7 +69,7 @@ class FactoryMuffin
      * @param string $model Model class name.
      * @param array  $attr  Model attributes.
      *
-     * @return mixed Returns the model instance.
+     * @return object
      */
     public static function instance($model, $attr = array())
     {
@@ -80,7 +82,7 @@ class FactoryMuffin
      * @param string $model Model class name.
      * @param array  $attr  Model attributes.
      *
-     * @return array Returns an attributes array.
+     * @return array
      */
     public static function attributesFor($model, $attr = array())
     {

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -30,7 +30,7 @@ class FactoryMuffin
      *
      * @throws \League\FactoryMuffin\Exception\Save
      *
-     * @return object The model instance.
+     * @return object
      */
     public function create($model, $attr = array())
     {
@@ -59,7 +59,7 @@ class FactoryMuffin
      * @param string $model Model class name.
      * @param array  $attr  Model attributes.
      *
-     * @return mixed Returns the model instance.
+     * @return object
      */
     public function instance($model, $attr = array())
     {
@@ -82,7 +82,7 @@ class FactoryMuffin
      * @param string $model Model class name.
      * @param array  $attr  Model attributes.
      *
-     * @return array Returns an attributes array.
+     * @return array
      */
     public function attributesFor($model, $attr = array())
     {
@@ -118,7 +118,7 @@ class FactoryMuffin
      *
      * @throws \League\FactoryMuffin\Exception\NoDefinedFactory
      *
-     * @return mixed A factory definition array.
+     * @return mixed
      */
     private function getFactoryAttrs($model)
     {
@@ -141,12 +141,12 @@ class FactoryMuffin
     }
 
     /**
-     * Generate attributes.
+     * Generate the attributes and return a string, or an instance of the model.
      *
      * @param string $kind  The kind of attribute that will be generate.
      * @param string $model The name of the model class.
      *
-     * @return mixed String or an instance of related model.
+     * @return string|object
      */
     public function generateAttr($kind, $model = null)
     {

--- a/src/Kind.php
+++ b/src/Kind.php
@@ -17,7 +17,7 @@ abstract class Kind
     /**
      * The Kind classes that are available.
      *
-     * @type array
+     * @type string[]
      */
     protected static $availableKinds = array(
         'call',
@@ -36,21 +36,21 @@ abstract class Kind
      *
      * @type \League\FactoryMuffin\Kind
      */
-    protected $kind = null;
+    protected $kind;
 
     /**
      * Holds the model data.
      *
      * @type array
      */
-    protected $model = null;
+    protected $model;
 
     /**
      * Holds the faker factory.
      *
      * @type \Faker\Factory
      */
-    protected $faker = null;
+    protected $faker;
 
     /**
      * Initialise our Kind.
@@ -76,7 +76,7 @@ abstract class Kind
      */
     public static function detect($kind, $model = null)
     {
-        // TODO Move this somewhere where its only instantiated once
+        // TODO: Move this somewhere where its only instantiated once
         $faker = new Faker;
 
         if ($kind instanceof \Closure) {
@@ -131,7 +131,7 @@ abstract class Kind
     }
 
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return mixed
      */

--- a/src/Kind/Call.php
+++ b/src/Kind/Call.php
@@ -17,7 +17,7 @@ use League\FactoryMuffin\Kind;
 class Call extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @throws \Exception
      *

--- a/src/Kind/Closure.php
+++ b/src/Kind/Closure.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class Closure extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return mixed
      */

--- a/src/Kind/Date.php
+++ b/src/Kind/Date.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class Date extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return mixed
      */

--- a/src/Kind/Factory.php
+++ b/src/Kind/Factory.php
@@ -16,24 +16,18 @@ use League\FactoryMuffin\Facade\FactoryMuffin;
 class Factory extends Kind
 {
     /**
-     * The factory methods.
+     * Generate, and return the attribute.
      *
-     * @type array
+     * @type string[]
      */
-    private $methods = array(
-        'getKey',
-        'pk',
-    );
+    private $methods = array('getKey', 'pk');
 
     /**
      * The factory properties.
      *
-     * @type array
+     * @type string[]
      */
-    private $properties = array(
-      'id',
-      '_id'
-    );
+    private $properties = array('id', '_id');
 
     /**
      * Return generated data.
@@ -51,7 +45,7 @@ class Factory extends Kind
      *
      * @param string $model Model class name.
      *
-     * @return int The model id if available.
+     * @return int
      */
     private function getId($model)
     {

--- a/src/Kind/Generic.php
+++ b/src/Kind/Generic.php
@@ -16,17 +16,17 @@ use League\FactoryMuffin\Kind;
 class Generic extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
-     * We attempt to use Faker for any string passed in, if a Faker property does
-     * not exist, then we just return the original string
+     * We attempt to use Faker for any string passed in.
+     * If a Faker property does not exist, we'll return the original string.
      *
      * @return mixed
      */
     public function generate()
     {
         // Only try and use Faker when there are no spaces in the string
-        if (! is_string($this->kind) or strpos($this->kind, ' ') !== false) {
+        if (!is_string($this->kind) or strpos($this->kind, ' ') !== false) {
             return $this->kind;
         }
 

--- a/src/Kind/Integer.php
+++ b/src/Kind/Integer.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class Integer extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return int
      */

--- a/src/Kind/Name.php
+++ b/src/Kind/Name.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class Name extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return string
      */

--- a/src/Kind/String.php
+++ b/src/Kind/String.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class String extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return string
      */

--- a/src/Kind/Text.php
+++ b/src/Kind/Text.php
@@ -15,7 +15,7 @@ use League\FactoryMuffin\Kind;
 class Text extends Kind
 {
     /**
-     * Return generated data.
+     * Generate, and return the attribute.
      *
      * @return string
      */


### PR DESCRIPTION
- I've removed any descriptions from the `@return` annotations. They can go in the short description.
- I've added a few missing fullstops on the descriptions.
- I've fixed a few return types
- I've made a few minor cs fixes
