### PR TITLE
Corrected Function Visibility

### DIFF
--- a/src/Facade/FactoryMuffin.php
+++ b/src/Facade/FactoryMuffin.php
@@ -28,13 +28,13 @@ class FactoryMuffin
      *
      * @return \League\FactoryMuffin\FactoryMuffin
      */
-    private static function fmInstance()
+    protected static function fmInstance()
     {
-        if (!static::$fmInstance) {
-            static::$fmInstance = new \League\FactoryMuffin\FactoryMuffin;
+        if (!self::$fmInstance) {
+            self::$fmInstance = new \League\FactoryMuffin\FactoryMuffin;
         }
 
-        return static::$fmInstance;
+        return self::$fmInstance;
     }
 
     /**


### PR DESCRIPTION
Because the `$fmInstance` property is private, we should refer to it in terms of `self` rather than static.

I've made the `fmInstance()` function protected so that it may be accessed by people extending the class, and so that the calls to it that are in terms of `static` rather than `self` make sence.
