### PR TITLE
Change `@type` back to `@var`

### DIFF
--- a/src/Exception/DeleteMethodNotFoundException.php
+++ b/src/Exception/DeleteMethodNotFoundException.php
@@ -16,7 +16,7 @@ class DeleteMethodNotFoundException extends MethodNotFoundException
     /**
      * The model instance.
      *
-     * @type object
+     * @var object
      */
     private $object;
 

--- a/src/Exception/DeletingFailedException.php
+++ b/src/Exception/DeletingFailedException.php
@@ -18,7 +18,7 @@ class DeletingFailedException extends Exception
     /**
      * The array of exceptions.
      *
-     * @type \Exception[]
+     * @var \Exception[]
      */
     private $exceptions;
 

--- a/src/Exception/DirectoryNotFoundException.php
+++ b/src/Exception/DirectoryNotFoundException.php
@@ -18,7 +18,7 @@ class DirectoryNotFoundException extends Exception
     /**
      * The path.
      *
-     * @type string
+     * @var string
      */
     private $path;
 

--- a/src/Exception/MethodNotFoundException.php
+++ b/src/Exception/MethodNotFoundException.php
@@ -16,7 +16,7 @@ class MethodNotFoundException extends ModelException
     /**
      * The method.
      *
-     * @type string
+     * @var string
      */
     private $method;
 

--- a/src/Exception/ModelException.php
+++ b/src/Exception/ModelException.php
@@ -18,7 +18,7 @@ class ModelException extends Exception
     /**
      * The model.
      *
-     * @type string
+     * @var string
      */
     private $model;
 

--- a/src/Exception/SaveFailedException.php
+++ b/src/Exception/SaveFailedException.php
@@ -16,7 +16,7 @@ class SaveFailedException extends ModelException
     /**
      * The errors.
      *
-     * @type string
+     * @var string
      */
     private $errors;
 

--- a/src/Exception/SaveMethodNotFoundException.php
+++ b/src/Exception/SaveMethodNotFoundException.php
@@ -16,7 +16,7 @@ class SaveMethodNotFoundException extends MethodNotFoundException
     /**
      * The model instance.
      *
-     * @type object
+     * @var object
      */
     private $object;
 

--- a/src/Facade/FactoryMuffin.php
+++ b/src/Facade/FactoryMuffin.php
@@ -34,7 +34,7 @@ class FactoryMuffin
     /**
      * The underline FactoryMuffin instance.
      *
-     * @type \League\FactoryMuffin\FactoryMuffin
+     * @var \League\FactoryMuffin\FactoryMuffin
      */
     private static $fmInstance;
 

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -27,28 +27,28 @@ class FactoryMuffin
     /**
      * The array of factories.
      *
-     * @type array
+     * @var array
      */
     private $factories = array();
 
     /**
      * The array of objects we have created.
      *
-     * @type array
+     * @var array
      */
     private $saved = array();
 
     /**
      * This is the method used when saving objects.
      *
-     * @type string
+     * @var string
      */
     private $saveMethod = 'save';
 
     /**
      * This is the method used when deleting objects.
      *
-     * @type string
+     * @var string
      */
     private $deleteMethod = 'delete';
 

--- a/src/Kind.php
+++ b/src/Kind.php
@@ -18,7 +18,7 @@ abstract class Kind
     /**
      * The Kind classes that are available.
      *
-     * @type string[]
+     * @var string[]
      */
     protected static $availableKinds = array(
         'call',
@@ -30,21 +30,21 @@ abstract class Kind
     /**
      * The kind of attribute that will be generated.
      *
-     * @type string
+     * @var string
      */
     protected $kind;
 
     /**
      * The model instance.
      *
-     * @type object
+     * @var object
      */
     protected $object;
 
     /**
      * The faker factory or generator instance.
      *
-     * @type \Faker\Factory|\Faker\Generator
+     * @var \Faker\Factory|\Faker\Generator
      */
     protected $faker;
 

--- a/src/Kind/Factory.php
+++ b/src/Kind/Factory.php
@@ -19,14 +19,14 @@ class Factory extends Kind
     /**
      * Generate, and return the attribute.
      *
-     * @type string[]
+     * @var string[]
      */
     private $methods = array('getKey', 'pk');
 
     /**
      * The factory properties.
      *
-     * @type string[]
+     * @var string[]
      */
     private $properties = array('id', '_id');
 


### PR DESCRIPTION
Although the psr proposed standard says that `@var` is deprecated, nobody seems to have actually followed that standard, and scrutinizer only supports `@var`.
