### PR TITLE
Optimised the __callStatic function

### DIFF
--- a/src/Facade/FactoryMuffin.php
+++ b/src/Facade/FactoryMuffin.php
@@ -77,8 +77,6 @@ class FactoryMuffin
                 return $instance->$method($args[0], $args[1]);
             case 3:
                 return $instance->$method($args[0], $args[1], $args[2]);
-            case 4:
-                return $instance->$method($args[0], $args[1], $args[2], $args[3]);
             default:
                 return call_user_func_array(array($instance, $method), $args);
         }


### PR DESCRIPTION
The 4th case can be removed from facade's __callStatic() method since that optimisation isn't needed because all methods only accept up to 3 parameters.
