### PR TITLE
Added An API Documentation Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ It maybe be useful for existing users to check out the [upgrade guide](UPGRADING
 
 ### Introduction
 
-This is the usage guide for Factory Muffin 2.0. Within this guide, you will see "the `xyz` function can be called". You should assume that these functions should be called statically on the `League\FactoryMuffin\Facade` class. It should also be noted that you can see a real example at the end of the guide.
+This is the usage guide for Factory Muffin 2.0. Within this guide, you will see "the `xyz` function can be called". You should assume that these functions should be called statically on the `League\FactoryMuffin\Facade` class. It should also be noted that we do have automatically generated api docs available [here](http://muffin.grahamjcampbell.co.uk/), and that you can see a full usage example at the end of the guide.
 
 ### The Facade
 


### PR DESCRIPTION
This is now being served by github pages using the https://github.com/GrahamCampbell/factory-muffin-api-docs repo.

---

//cc @scottrobertson
