### PR TITLE
Updated Readme Install Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ It's basically a "[factory\_girl](https://github.com/thoughtbot/factory_girl)", 
 
 [PHP](https://php.net) 5.3+ and [Composer](https://getcomposer.org) are required.
 
-In your composer.json, simply add `"league/factory-muffin": "~2.0@dev"` to your `"require-dev"` section:
+In your composer.json, simply add `"league/factory-muffin": "~2.0"` to your `"require-dev"` section:
 ```json
 {
     "require-dev": {
-        "league/factory-muffin": "~2.0@dev"
+        "league/factory-muffin": "~2.0"
     }
 }
 ```


### PR DESCRIPTION
This removes the `@dev` flags from the readme's install guide. 

**This should be merged just before we release v2.0.0.**
