### PR TITLE
Also test against hhvm-nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ php:
   - 5.5
   - 5.6
   - hhvm
+  - hhvm-nightly
 
 before_script:
   - travis_retry composer self-update


### PR DESCRIPTION
This should allow us to spot any regressions in hhvm causing incompatibility with Factory Muffin so we can flag them up with the hhvm team before they reach the next hhvm tag.
