### PR TITLE
Stricter Faker Dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "fzaninotto/faker" : "~1.3"
+        "fzaninotto/faker" : "1.4.*"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
Should we make this version constraint stricter in case the faker library introduces bc breaks which may be unexpected for our users? Doing this will allow us to notify our users of things in our upgrading guide as we change the version constraint for faker updates.
