### PR TITLE
[2.1] Fixed A Major Issue With The Groups

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -218,7 +218,9 @@ class Factory
      */
     private function getGroup($model)
     {
-        return current(explode(':', $model));
+        if (strpos($model, ':') !== false) {
+            return current(explode(':', $model));
+        }
     }
 
     /**
@@ -235,7 +237,7 @@ class Factory
             return str_replace($group . ':', '', $model);
         }
 
-        return $group;
+        return $model;
     }
 
     /**


### PR DESCRIPTION
I did some debugging that uncovered that the `getGroup` function was not behaving as we expected. It was not returning `null` when there was no group prefix, but was in fact returning the model class name. I've fixed this, and also corrected a typo in the `getModelClass` function that we were actually getting away with before due to the broken `getGroup` function.

---

//cc @scottrobertson
