### PR TITLE
Mark our strictly internal classes as final

### DIFF
--- a/src/Generators/Call.php
+++ b/src/Generators/Call.php
@@ -18,7 +18,7 @@ use League\FactoryMuffin\Facade as FactoryMuffin;
  * @author  Graham Campbell <graham@mineuk.com>
  * @license <https://github.com/thephpleague/factory-muffin/blob/master/LICENSE> MIT
  */
-class Call extends Base
+final class Call extends Base
 {
     /**
      * Generate, and return the attribute.

--- a/src/Generators/Closure.php
+++ b/src/Generators/Closure.php
@@ -18,7 +18,7 @@ use League\FactoryMuffin\Facade as FactoryMuffin;
  * @author  Graham Campbell <graham@mineuk.com>
  * @license <https://github.com/thephpleague/factory-muffin/blob/master/LICENSE> MIT
  */
-class Closure extends Base
+final class Closure extends Base
 {
     /**
      * Generate, and return the attribute.

--- a/src/Generators/Factory.php
+++ b/src/Generators/Factory.php
@@ -16,7 +16,7 @@ namespace League\FactoryMuffin\Generators;
  * @author  Graham Campbell <graham@mineuk.com>
  * @license <https://github.com/thephpleague/factory-muffin/blob/master/LICENSE> MIT
  */
-class Factory extends Base
+final class Factory extends Base
 {
     /**
      * Generate, and return the attribute.

--- a/src/Generators/Generic.php
+++ b/src/Generators/Generic.php
@@ -18,7 +18,7 @@ use InvalidArgumentException;
  * @author  Graham Campbell <graham@mineuk.com>
  * @license <https://github.com/thephpleague/factory-muffin/blob/master/LICENSE> MIT
  */
-class Generic extends Base
+final class Generic extends Base
 {
     /**
      * Generate, and return the attribute.


### PR DESCRIPTION
Although our class level description already clearly says that these classes are "not be considered part of the public api, and should only be used internally by Factory Muffin", I don't think we're pushing the point hard enough. I propose we add the final keyword to our classes. This is not a breaking change because nobody should be modifying those classes.
