### PR TITLE
Set the att value on the model once generated.

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -324,11 +324,7 @@ class FactoryMuffin
         }
 
         // Get the factory attributes for that model
-        $attributes = $this->attributesFor($object, $attr);
-
-        foreach ($attributes as $name => $value) {
-            $this->setAttribute($object, $name, $value);
-        }
+        $this->attributesFor($object, $attr);
 
         return $object;
     }
@@ -569,6 +565,7 @@ class FactoryMuffin
         // Prepare attributes
         foreach ($attributes as $key => $kind) {
             $attr[$key] = $this->generatorFactory->generate($kind, $object);
+            $this->setAttribute($object, $key, $attr[$key]);
         }
 
         return $attr;


### PR DESCRIPTION
This allows generators of the 'Closure' type to access attributes immediately after they are generated via the object that is passed in as the first param.
