### PR TITLE
These properties should be private

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -23,21 +23,21 @@ class FactoryGenerator implements GeneratorInterface
      *
      * @var string
      */
-    protected $kind;
+    private $kind;
 
     /**
      * The model instance.
      *
      * @var object
      */
-    protected $object;
+    private $object;
 
     /**
      * The factory muffin instance.
      *
      * @var \League\FactoryMuffin\FactoryMuffin
      */
-    protected $factoryMuffin;
+    private $factoryMuffin;
 
     /**
      * Create a new instance.


### PR DESCRIPTION
These had the wrong visibility after I refactored the generators. What is now the "GeneratorFactory" used to be a base generator class the others extended.
