### PR TITLE
Allow callback to determine if a second persist is needed

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -301,8 +301,8 @@ class Factory
     {
         if ($callback = Arr::get($this->callbacks, $model)) {
             $saved = $this->isPendingOrSaved($object);
-            $callback($object, $saved);
-            return true;
+            /** @var callable $callback */
+            return $callback($object, $saved) !== false;
         }
 
         return false;

--- a/tests/SaveAndDeleteTest.php
+++ b/tests/SaveAndDeleteTest.php
@@ -195,6 +195,17 @@ class SaveAndDeleteTest extends AbstractTestCase
             throw $e;
         }
     }
+
+    public function testModelIsNotPersistedASecondTimeIfClosureReturnsFalse()
+    {
+        $obj1 = FactoryMuffin::create('no return:ModelWithTrackedSaves');
+        $obj2 = FactoryMuffin::create('return true:ModelWithTrackedSaves');
+        $obj3 = FactoryMuffin::create('return false:ModelWithTrackedSaves');
+
+        $this->assertEquals(2, $obj1->saveCounter);
+        $this->assertEquals(2, $obj2->saveCounter);
+        $this->assertEquals(1, $obj3->saveCounter);
+    }
 }
 
 class ModelThatWillSaveStub
@@ -274,6 +285,23 @@ class ModelWithValidationErrorsStub
     public function save()
     {
 
+    }
+
+    public function delete()
+    {
+        return true;
+    }
+}
+
+class ModelWithTrackedSaves
+{
+    public $saveCounter = 0;
+
+    public function save()
+    {
+        $this->saveCounter++;
+
+        return true;
     }
 
     public function delete()

--- a/tests/factories/savedelete.php
+++ b/tests/factories/savedelete.php
@@ -9,3 +9,13 @@ FactoryMuffin::define('ModelThatAlsoFailsToDeleteStub', array());
 FactoryMuffin::define('ModelWithNoSaveMethodStub', array());
 FactoryMuffin::define('ModelWithNoDeleteMethodStub', array());
 FactoryMuffin::define('ModelWithValidationErrorsStub', array());
+FactoryMuffin::define('ModelWithTrackedSaves', array());
+FactoryMuffin::define('no return:ModelWithTrackedSaves', array(), function () {
+    // No return is treated truthie
+});
+FactoryMuffin::define('return true:ModelWithTrackedSaves', array(), function () {
+    return true;
+});
+FactoryMuffin::define('return false:ModelWithTrackedSaves', array(), function () {
+    return false;
+});


### PR DESCRIPTION
As requested in #350

I based this on 2.1 since it doesn't break any current functionality
