### PR TITLE
Even more flexibility when defining group definitions

### DIFF
--- a/src/Definition.php
+++ b/src/Definition.php
@@ -26,13 +26,6 @@ use Closure;
 class Definition
 {
     /**
-     * The model group.
-     *
-     * @var string|null
-     */
-    protected $group;
-
-    /**
      * The model class name.
      *
      * @var string
@@ -40,11 +33,11 @@ class Definition
     protected $class;
 
     /**
-     * The full model name.
+     * The model group.
      *
-     * @var string
+     * @var string|null
      */
-    protected $model;
+    protected $group;
 
     /**
      * The closure callback.
@@ -63,30 +56,13 @@ class Definition
     /**
      * Create a new model definition.
      *
-     * @param string $model The full model name.
+     * @param string $class The model class name.
      *
      * @return void
      */
-    public function __construct($model)
+    public function __construct($class)
     {
-        if (strpos($model, ':') !== false) {
-            $this->group = current(explode(':', $model));
-            $this->class = str_replace($this->group.':', '', $model);
-        } else {
-            $this->class = $model;
-        }
-
-        $this->model = $model;
-    }
-
-    /**
-     * Get the definition group.
-     *
-     * @return string|null
-     */
-    public function getGroup()
-    {
-        return $this->group;
+        $this->class = $class;
     }
 
     /**
@@ -100,13 +76,27 @@ class Definition
     }
 
     /**
-     * Get the full model name including group prefixes.
+     * Set the model group.
      *
-     * @return string
+     * @param string|null $group
+     *
+     * @return $this
      */
-    public function getModel()
+    public function setGroup($group)
     {
-        return $this->model;
+        $this->group = $group;
+
+        return $this;
+    }
+
+    /**
+     * Get the model group.
+     *
+     * @return string|null
+     */
+    public function getGroup()
+    {
+        return $this->group;
     }
 
     /**

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -44,7 +44,6 @@ class DefinitionTest extends AbstractTestCase
 
         $this->assertNull($definition->getGroup());
         $this->assertSame('AttributeDefinitionsStub', $definition->getClass());
-        $this->assertSame('AttributeDefinitionsStub', $definition->getModel());
     }
 
     public function testAttributeDefinitionFunctions()
@@ -93,6 +92,7 @@ class DefinitionTest extends AbstractTestCase
         ]);
 
         $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertSame('foo', $user->test);
         $this->assertInternalType('string', $user->name);
         $this->assertInternalType('string', $user->fullName);
         $this->assertNotEquals('name', $user->fullName);
@@ -119,6 +119,7 @@ class DefinitionTest extends AbstractTestCase
         $user = static::$fm->create('group:UserModelStub');
 
         $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertSame('foo', $user->test);
         $this->assertInternalType('string', $user->address);
         $this->assertNotEquals('address', $user->address);
         $this->assertInternalType('string', $user->name);
@@ -131,10 +132,19 @@ class DefinitionTest extends AbstractTestCase
         $user = static::$fm->create('anothergroup:UserModelStub');
 
         $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertSame('foo', $user->test);
         $this->assertInternalType('string', $user->address);
         $this->assertInternalType('string', $user->name);
         $this->assertSame('custom', $user->active);
         $this->assertContains('@', $user->email);
+    }
+
+    public function testGroupKeepCallback()
+    {
+        $user = static::$fm->create('UserModelStub');
+
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertSame('foo', $user->test);
     }
 
     public function testGroupCallback()
@@ -146,6 +156,17 @@ class DefinitionTest extends AbstractTestCase
         $this->assertInternalType('string', $user->name);
         $this->assertInternalType('boolean', $user->active);
         $this->assertContains('@', $user->email);
+    }
+
+    public function testGroupClearAttributes()
+    {
+        $user = static::$fm->create('noattributes:UserModelStub');
+
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertSame('foo', $user->test);
+        $this->assertFalse(isset($user->name));
+        $this->assertFalse(isset($user->active));
+        $this->assertFalse(isset($user->email));
     }
 
     /**
@@ -168,7 +189,10 @@ class DefinitionTest extends AbstractTestCase
     public function testGroupDefineNoBaseModel()
     {
         try {
-            static::$fm->create('foo:DogModelStub');
+            static::$fm->define('foo:DogModelStub')->setDefinitions([
+                'name' => Faker::firstNameMale(),
+                'age'  => Faker::numberBetween(1, 15),
+            ]);
         } catch (NoDefinedFactoryException $e) {
             $this->assertSame("No model definition was defined for the model: 'DogModelStub'.", $e->getMessage());
             $this->assertSame('DogModelStub', $e->getModel());

--- a/tests/factories/definition.php
+++ b/tests/factories/definition.php
@@ -25,7 +25,9 @@ $fm->define('UserModelStub')->setDefinitions([
     'active'  => Faker::boolean(),
     'email'   => Faker::email(),
     'profile' => 'factory|ProfileModelStub',
-]);
+])->setCallback(function ($obj) {
+    $obj->test = 'foo';
+});
 
 $fm->define('group:UserModelStub')->addDefinition('address', Faker::address());
 
@@ -38,10 +40,7 @@ $fm->define('callbackgroup:UserModelStub')->setCallback(function ($obj) {
     $obj->test = 'bar';
 });
 
-$fm->define('foo:DogModelStub')->setDefinitions([
-    'name' => Faker::firstNameMale(),
-    'age'  => Faker::numberBetween(1, 15),
-]);
+$fm->define('noattributes:UserModelStub')->clearDefinitions();
 
 $fm->define('ExampleCallbackStub')->setCallback(function ($obj, $saved) {
     $obj->callback = 'yaycalled';


### PR DESCRIPTION
When someone wants to define a group definition, they are now given a clone of the original model definition to work with allowing them to modify the original callback and attributes easily. This also means if they don't explicitly set a callback for the group, we're still executing the original one.
