### PR TITLE
[3.0] Added Custom Makers Per Definition

### DIFF
--- a/src/Definition.php
+++ b/src/Definition.php
@@ -40,7 +40,14 @@ class Definition
     protected $group;
 
     /**
-     * The closure callback.
+     * The maker closure.
+     *
+     * @var \Closure|null
+     */
+    protected $maker;
+
+    /**
+     * The callback closure.
      *
      * @var \Closure|null
      */
@@ -100,7 +107,43 @@ class Definition
     }
 
     /**
-     * Set the closure callback.
+     * Set the maker closure.
+     *
+     * @param \Closure $maker
+     *
+     * @return $this
+     */
+    public function setMaker(Closure $maker)
+    {
+        $this->maker = $maker;
+
+        return $this;
+    }
+
+    /**
+     * Clear the maker closure.
+     *
+     * @return $this
+     */
+    public function clearMaker()
+    {
+        $this->maker = null;
+
+        return $this;
+    }
+
+    /**
+     * Get the maker closure.
+     *
+     * @return \Closure|null
+     */
+    public function getMaker()
+    {
+        return $this->maker;
+    }
+
+    /**
+     * Set the callback closure.
      *
      * @param \Closure $callback
      *
@@ -114,7 +157,7 @@ class Definition
     }
 
     /**
-     * Clear the closure callback.
+     * Clear the callback closure.
      *
      * @return $this
      */
@@ -126,7 +169,7 @@ class Definition
     }
 
     /**
-     * Get the closure callback.
+     * Get the callback closure.
      *
      * @return \Closure|null
      */

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -14,6 +14,7 @@
 
 namespace League\FactoryMuffin;
 
+use Closure;
 use Exception;
 use League\FactoryMuffin\Exceptions\DeleteFailedException;
 use League\FactoryMuffin\Exceptions\DeleteMethodNotFoundException;
@@ -208,7 +209,7 @@ class FactoryMuffin
     protected function make($model, array $attr, $save)
     {
         $definition = $this->getDefinition($model);
-        $object = $this->makeClass($definition->getClass());
+        $object = $this->makeClass($definition->getClass(), $definition->getMaker());
 
         // Make the object as saved so that other generators persist correctly
         if ($save) {
@@ -227,16 +228,21 @@ class FactoryMuffin
     /**
      * Make an instance of the class.
      *
-     * @param string $class The class name.
+     * @param string        $class The class name.
+     * @param \Closure|null $maker The maker closure.
      *
      * @throws \League\FactoryMuffin\Exceptions\ModelNotFoundException
      *
      * @return object
      */
-    protected function makeClass($class)
+    protected function makeClass($class, Closure $maker = null)
     {
         if (!class_exists($class)) {
             throw new ModelNotFoundException($class);
+        }
+
+        if ($maker) {
+            return $maker($class);
         }
 
         return new $class();

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -285,6 +285,30 @@ class DefinitionTest extends AbstractTestCase
 
         $this->assertInstanceOf('ProfileModelStub', $obj->profile);
     }
+
+    public function testCustomMaker()
+    {
+        $obj = static::$fm->instance('CustomMakerStub');
+
+        $this->assertInstanceOf('CustomMakerStub', $obj);
+        $this->assertSame('qwerty', $obj->foo);
+    }
+
+    public function testCustomMakerGroup()
+    {
+        $obj = static::$fm->instance('group:CustomMakerStub');
+
+        $this->assertInstanceOf('CustomMakerStub', $obj);
+        $this->assertSame('qwertyuiop', $obj->foo);
+    }
+
+    public function testNoMakerGroup()
+    {
+        $obj = static::$fm->instance('clear:CustomMakerStub');
+
+        $this->assertInstanceOf('CustomMakerStub', $obj);
+        $this->assertSame('bar', $obj->foo);
+    }
 }
 
 class AttributeDefinitionsStub
@@ -360,6 +384,26 @@ class ExampleCallbackStub
 class AnotherCallbackStub
 {
     public $foo;
+
+    public function save()
+    {
+        return true;
+    }
+
+    public function delete()
+    {
+        return true;
+    }
+}
+
+class CustomMakerStub
+{
+    public $foo;
+
+    public function __construct($foo = 'bar')
+    {
+        $this->foo = $foo;
+    }
 
     public function save()
     {

--- a/tests/factories/definition.php
+++ b/tests/factories/definition.php
@@ -51,3 +51,13 @@ $fm->define('AnotherCallbackStub')->addDefinition('foo', Faker::email())->setCal
     $obj->foo = 'hello there';
     $obj->saved = $saved;
 });
+
+$fm->define('CustomMakerStub')->setMaker(function ($class) {
+    return new $class('qwerty');
+});
+
+$fm->define('group:CustomMakerStub')->setMaker(function ($class) {
+    return new $class('qwertyuiop');
+});
+
+$fm->define('clear:CustomMakerStub')->clearMaker();


### PR DESCRIPTION
In Factory Muffin 3.0, the ability to register custom makers/setters/deleters on the factory muffin class has been removed because it was quite poorly designed, and the model definition registration has been improved massively fixing a few design problems we had before, and improving the definition group functionality.

I now propose that we allow people to register custom makers during this definition registration process, so in the same way you can define attribute definitions and callback for your models, you will also be able to register a custom maker closure.

Ok, so what does this mean for my code then?

Factory Muffin 2.1:

``` php
FactoryMuffin::define('Foo', []);
FactoryMuffin::define('extra:Foo', ['user' => 'firstNameMale']);
FactoryMuffin::define('Bar', []);
FactoryMuffin::define('Baz', []);

// no way to handle makers custom to groups
// we have to do this all at once - not very flexible
FactoryMuffin::setCustomMaker(function($class) {
    if ($class === 'Foo') {
        return new $class('bar');
    } elseif ($class === 'Bar') {
        return new $class('baz');
    } else {
        return new $class();
    }
});
```

Factory Muffin 3.0:

``` php
$fm = new FactoryMuffin();

$fm->define('Foo')
    ->setMaker(function ($class) {
        return new $class('bar');
});

$fm->define('extra:Foo')
    ->addDefinition('user', Faker::firstNameMale())
    ->setMaker(function ($class) {
        return new $class('hello');
});

$fm->define('Bar')
    ->setMaker(function ($class) {
        return new $class('baz');
});

$fm->define('Baz');
```
