### PR TITLE
Attribute definition overwriting fix

### DIFF
--- a/src/Factory.php
+++ b/src/Factory.php
@@ -330,7 +330,7 @@ class Factory
 
         // Get the group specific factory attributes
         if ($group) {
-            $attr = array_merge($attr, $this->getFactoryAttrs($model));
+            $attr = array_merge($this->getFactoryAttrs($model), $attr);
         }
 
         // Get the factory attributes for that model

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -98,7 +98,6 @@ class DefinitionTest extends AbstractTestCase
         $this->assertContains('@', $user->email);
         $this->assertInternalType('integer', $user->age);
 
-        $this->markTestSkipped('Fix has not yet been implemented.');
         $this->assertSame(50, $user->age);
     }
 

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -34,6 +34,20 @@ class DefinitionTest extends AbstractTestCase
         $this->assertContains('@', $user->email);
     }
 
+    public function testDefineWithReplacementGeneratorsOverwrite()
+    {
+        $user = FactoryMuffin::create('UserModelStub', array(
+            'age' => 'numberBetween|50;50'
+        ));
+
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertInternalType('string', $user->name);
+        $this->assertInternalType('boolean', $user->active);
+        $this->assertContains('@', $user->email);
+        $this->assertInternalType('integer', $user->age);
+        $this->assertSame(50, $user->age);
+    }
+
     /**
      * @expectedException \League\FactoryMuffin\Exceptions\ModelNotFoundException
      */
@@ -70,6 +84,22 @@ class DefinitionTest extends AbstractTestCase
         $this->assertNotInternalType('boolean', $user->active);
         $this->assertSame('false', $user->active);
         $this->assertContains('@', $user->email);
+    }
+
+    public function testGroupDefineWithReplacementGeneratorsOverwrite()
+    {
+        $user = FactoryMuffin::create('centenarian:UserModelStub', array(
+            'age' => 'numberBetween|50;50'
+        ));
+
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertInternalType('string', $user->name);
+        $this->assertInternalType('boolean', $user->active);
+        $this->assertContains('@', $user->email);
+        $this->assertInternalType('integer', $user->age);
+
+        $this->markTestSkipped('Fix has not yet been implemented.');
+        $this->assertSame(50, $user->age);
     }
 
     public function testGroupCallback()

--- a/tests/factories/definition.php
+++ b/tests/factories/definition.php
@@ -10,6 +10,7 @@ FactoryMuffin::define('UserModelStub', array(
     'name'    => 'word',
     'active'  => 'boolean',
     'email'   => 'email',
+    'age'     => 'numberBetween|18;35',
     'profile' => 'factory|ProfileModelStub',
 ));
 
@@ -20,6 +21,10 @@ FactoryMuffin::define('group:UserModelStub', array(
 FactoryMuffin::define('anothergroup:UserModelStub', array(
     'address' => 'address',
     'active'  => 'false',
+));
+
+FactoryMuffin::define('centenarian:UserModelStub', array(
+    'age' => 'numberBetween|100;100',
 ));
 
 FactoryMuffin::define('callbackgroup:UserModelStub', array(), function($obj) {


### PR DESCRIPTION
When passing attribute definitions to create()/instance() it is unclear from the documentation how conflicts between the passed definitions and definitions created by calls to define() should be resolved.

I had expected that the generators specified when calling create() or instance() should override those set by define(), but when using a factory with a group definition, the group definitions over write what was passed as a parameter to create().

Previous behavior:

group factory generators > generators passed as parameters to create() > base model factory generators

this change:

generators passed as parameters to create() > group factory generators > base model factory generators