### PR TITLE
Add tests demonstrating inconsistent attribute definition overwrites

### DIFF
--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -93,7 +93,22 @@ class DefinitionTest extends AbstractTestCase
         $this->assertInternalType('string', $user->fullName);
         $this->assertNotEquals('name', $user->fullName);
         $this->assertInternalType('boolean', $user->active);
+        $this->assertInternalType('integer', $user->age);
+        $this->assertTrue($user->age >= 18 && $user->age <= 35);
         $this->assertContains('@', $user->email);
+    }
+
+    public function testDefineWithReplacementGeneratorsOverwrite()
+    {
+        $user = static::$fm->create('centenarian:UserModelStub', [
+            'age' => Faker::numberBetween(50, 50),
+        ]);
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertInternalType('string', $user->name);
+        $this->assertInternalType('boolean', $user->active);
+        $this->assertContains('@', $user->email);
+        $this->assertInternalType('integer', $user->age);
+        $this->assertSame(50, $user->age);
     }
 
     /**
@@ -133,6 +148,19 @@ class DefinitionTest extends AbstractTestCase
         $this->assertInternalType('string', $user->name);
         $this->assertSame('custom', $user->active);
         $this->assertContains('@', $user->email);
+    }
+
+    public function testGroupDefineWithReplacementGeneratorsOverwrite()
+    {
+        $user = static::$fm->create('centenarian:UserModelStub', [
+            'age' => Faker::numberBetween(50, 50),
+        ]);
+        $this->assertInstanceOf('UserModelStub', $user);
+        $this->assertInternalType('string', $user->name);
+        $this->assertInternalType('boolean', $user->active);
+        $this->assertContains('@', $user->email);
+        $this->assertInternalType('integer', $user->age);
+        $this->assertSame(50, $user->age);
     }
 
     public function testGroupKeepCallback()

--- a/tests/factories/definition.php
+++ b/tests/factories/definition.php
@@ -22,6 +22,7 @@ $fm->define('UserModelStub')->setDefinitions([
     'name'    => Faker::word(),
     'active'  => Faker::boolean(),
     'email'   => Faker::email(),
+    'age'     => Faker::numberBetween(18, 35),
     'profile' => 'factory|ProfileModelStub',
 ])->setCallback(function ($obj) {
     $obj->test = 'foo';
@@ -32,6 +33,10 @@ $fm->define('group:UserModelStub')->addDefinition('address', Faker::address());
 $fm->define('anothergroup:UserModelStub')->setDefinitions([
     'address' => Faker::address(),
     'active'  => 'custom',
+]);
+
+$fm->define('centenarian:UserModelStub')->setDefinitions([
+    'age' => Faker::numberBetween(100, 100),
 ]);
 
 $fm->define('callbackgroup:UserModelStub')->setCallback(function ($obj) {


### PR DESCRIPTION
Rewrite of test from #379 for 3.0: rewrote for new interface and changed to match short array syntax style.

@GrahamCampbell This doesn't need to be merged, but I'm creating the PR just to follow up. It seems 3.0 already "corrects" the behavior so its definition overwrites behave like #379 and not 2.1 already. 

Cheers! :beers: 

_____

When passing attribute definitions to create()/instance() it is unclear from the documentation how conflicts between the passed definitions and definitions created by calls to define() should be resolved.

testDefineWithReplacementGeneratorsOverwrite() demonstrates what I intuit to be expected behavior: the definitions passed to create() overwrite previous definitions.

testGroupDefineWithReplacementGeneratorsOverwrite() demonstrates behavior that conflicts with the above. The definition defined by the group factory overwrites the definitions passed in to create().