### PR TITLE
Enhancement: Require fzaninotto/faker:^1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "fzaninotto/faker" : "1.4.*"
+        "fzaninotto/faker": "^1.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -18,7 +18,7 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertArrayHasKey('name', $obj->card);
         $this->assertArrayHasKey('expirationDate', $obj->card);
 
-        $this->assertSame('http://lorempixel.com/400/600/', $obj->image);
+        $this->assertStringStartsWith('http://lorempixel.com/400/600/', $obj->image);
         $this->assertNotEquals('unique::text', $obj->unique_text);
         $this->assertNotEquals('optional::text', $obj->optional_text);
     }


### PR DESCRIPTION
:exclamation: Blocked by https://github.com/thephpleague/factory-muffin/pull/400.

This PR

* [x] requires `fzaninotto/faker:^1.5` so we can use it in projects already requiring the latest versions of `fzaninotto/faker`
* [x] fixes the test by asserting that the image url starts with the expected url