### PR TITLE
Adds support for setting model attributes through setters

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -55,7 +55,7 @@ class FactoryMuffin
     /**
      * Create a new factory muffin instance.
      *
-     * @param \League\FactoryMuffin\ModelStore|null                  $modelStore       The model store instance.
+     * @param \League\FactoryMuffin\ModelStore|null $modelStore The model store instance.
      * @param \League\FactoryMuffin\Generators\GeneratorFactory|null $generatorFactory The generator factory instance.
      *
      * @return void
@@ -99,9 +99,9 @@ class FactoryMuffin
      *
      * Under the hood, we're calling the create method over and over.
      *
-     * @param int    $times The number of models to create.
-     * @param string $name  The model definition name.
-     * @param array  $attr  The model attributes.
+     * @param int $times The number of models to create.
+     * @param string $name The model definition name.
+     * @param array $attr The model attributes.
      *
      * @return object[]
      */
@@ -120,7 +120,7 @@ class FactoryMuffin
      * Creates and saves a model.
      *
      * @param string $name The model definition name.
-     * @param array  $attr The model attributes.
+     * @param array $attr The model attributes.
      *
      * @return object
      */
@@ -141,7 +141,7 @@ class FactoryMuffin
      * Trigger the callback if we have one.
      *
      * @param object $model The model instance.
-     * @param string $name  The model definition name.
+     * @param string $name The model definition name.
      *
      * @return bool
      */
@@ -162,8 +162,8 @@ class FactoryMuffin
      * Make an instance of a model.
      *
      * @param string $name The model definition name.
-     * @param array  $attr The model attributes.
-     * @param bool   $save Are we saving, or just creating an instance?
+     * @param array $attr The model attributes.
+     * @param bool $save Are we saving, or just creating an instance?
      *
      * @return object
      */
@@ -189,7 +189,7 @@ class FactoryMuffin
     /**
      * Make an instance of a class.
      *
-     * @param string        $class The model class name.
+     * @param string $class The model class name.
      * @param callable|null $maker The maker callable.
      *
      * @throws \League\FactoryMuffin\Exceptions\ModelNotFoundException
@@ -239,7 +239,7 @@ class FactoryMuffin
      * This does not save it in the database. Use create for that.
      *
      * @param string $name The model definition name.
-     * @param array  $attr The model attributes.
+     * @param array $attr The model attributes.
      *
      * @return object
      */
@@ -256,7 +256,7 @@ class FactoryMuffin
      * Generate and set the model attributes.
      *
      * @param object $model The model instance.
-     * @param array  $attr  The model attributes.
+     * @param array $attr The model attributes.
      *
      * @return void
      */
@@ -265,10 +265,10 @@ class FactoryMuffin
         foreach ($attr as $key => $kind) {
             $value = $this->generatorFactory->generate($kind, $model, $this);
 
-            $setter = 'set'.$this->camelize($key);
+            $setter = 'set' . $this->camelize($key);
 
             // check if there is a setter and use it instead
-            if(method_exists($model, $setter)){
+            if (method_exists($model, $setter)) {
                 $model->$setter($value);
             } else {
                 $model->$key = $value;
@@ -314,7 +314,7 @@ class FactoryMuffin
 
         if (strpos($name, ':') !== false) {
             $group = current(explode(':', $name));
-            $class = str_replace($group.':', '', $name);
+            $class = str_replace($group . ':', '', $name);
             $this->definitions[$name] = clone $this->getDefinition($class);
             $this->definitions[$name]->setGroup($group);
         } else {
@@ -339,7 +339,7 @@ class FactoryMuffin
      */
     public function loadFactories($paths)
     {
-        foreach ((array) $paths as $path) {
+        foreach ((array)$paths as $path) {
             if (!is_dir($path)) {
                 throw new DirectoryNotFoundException($path);
             }
@@ -374,18 +374,19 @@ class FactoryMuffin
 
     /**
      * Translates a string with underscores
-     * into camel case (e.g. first_name -> firstName)
+     * into camel case (e.g. first_name -> firstName).
      *
-     * @param string $str String in underscore format
-     * @param bool $capitaliseFirstChar If true, capitalise the first char in $str
+     * @param string $str                 String in underscore format
+     * @param bool   $capitaliseFirstChar If true, capitalise the first char in $str
      * @return string $str translated into camel caps
      */
-    function camelize($str, $capitaliseFirstChar = false) {
-        if($capitaliseFirstChar) {
+    public function camelize($str, $capitaliseFirstChar = false)
+    {
+        if ($capitaliseFirstChar) {
             $str[0] = strtoupper($str[0]);
         }
 
-        return preg_replace_callback('/_([a-z])/', function($c){
+        return preg_replace_callback('/_([a-z])/', function ($c) {
             return strtoupper($c[1]);
         }, $str);
     }

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -263,7 +263,16 @@ class FactoryMuffin
     protected function generate($model, array $attr = [])
     {
         foreach ($attr as $key => $kind) {
-            $model->$key = $this->generatorFactory->generate($kind, $model, $this);
+            $value = $this->generatorFactory->generate($kind, $model, $this);
+
+            $setter = 'set'.$this->camelize($key);
+
+            // check if there is a setter and use it instead
+            if(method_exists($model, $setter)){
+                $model->$setter($value);
+            } else {
+                $model->$key = $value;
+            }
         }
     }
 
@@ -361,5 +370,23 @@ class FactoryMuffin
         foreach ($files as $file) {
             require $file->getPathName();
         }
+    }
+
+    /**
+     * Translates a string with underscores
+     * into camel case (e.g. first_name -> firstName)
+     *
+     * @param string $str String in underscore format
+     * @param bool $capitaliseFirstChar If true, capitalise the first char in $str
+     * @return string $str translated into camel caps
+     */
+    function camelize($str, $capitaliseFirstChar = false) {
+        if($capitaliseFirstChar) {
+            $str[0] = strtoupper($str[0]);
+        }
+
+        return preg_replace_callback('/_([a-z])/', function($c){
+            return strtoupper($c[1]);
+        }, $str);
     }
 }

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -381,7 +381,7 @@ class FactoryMuffin
      *
      * @return string $str translated into camel caps
      */
-    function camelize($str, $capitaliseFirstChar = false)
+    public function camelize($str, $capitaliseFirstChar = false)
     {
         if ($capitaliseFirstChar) {
             $str[0] = strtoupper($str[0]);

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -377,7 +377,7 @@ class FactoryMuffin
      *
      * Transforms a string to camel case (e.g. first_name -> firstName).
      *
-     * @param string $str                 String in underscore format
+     * @param string $str String in underscore format
      *
      * @return string $str translated into camel caps
      */

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -376,11 +376,12 @@ class FactoryMuffin
      * Translates a string with underscores
      * into camel case (e.g. first_name -> firstName).
      *
-     * @param string $str                 String in underscore format
-     * @param bool   $capitaliseFirstChar If true, capitalise the first char in $str
+     * @param string $str String in underscore format
+     * @param bool $capitaliseFirstChar If true, capitalise the first char in $str
+     *
      * @return string $str translated into camel caps
      */
-    public function camelize($str, $capitaliseFirstChar = false)
+    function camelize($str, $capitaliseFirstChar = false)
     {
         if ($capitaliseFirstChar) {
             $str[0] = strtoupper($str[0]);

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -55,7 +55,7 @@ class FactoryMuffin
     /**
      * Create a new factory muffin instance.
      *
-     * @param \League\FactoryMuffin\ModelStore|null $modelStore The model store instance.
+     * @param \League\FactoryMuffin\ModelStore|null                  $modelStore       The model store instance.
      * @param \League\FactoryMuffin\Generators\GeneratorFactory|null $generatorFactory The generator factory instance.
      *
      * @return void
@@ -99,9 +99,9 @@ class FactoryMuffin
      *
      * Under the hood, we're calling the create method over and over.
      *
-     * @param int $times The number of models to create.
-     * @param string $name The model definition name.
-     * @param array $attr The model attributes.
+     * @param int    $times The number of models to create.
+     * @param string $name  The model definition name.
+     * @param array  $attr  The model attributes.
      *
      * @return object[]
      */
@@ -120,7 +120,7 @@ class FactoryMuffin
      * Creates and saves a model.
      *
      * @param string $name The model definition name.
-     * @param array $attr The model attributes.
+     * @param array  $attr The model attributes.
      *
      * @return object
      */
@@ -141,7 +141,7 @@ class FactoryMuffin
      * Trigger the callback if we have one.
      *
      * @param object $model The model instance.
-     * @param string $name The model definition name.
+     * @param string $name  The model definition name.
      *
      * @return bool
      */
@@ -162,8 +162,8 @@ class FactoryMuffin
      * Make an instance of a model.
      *
      * @param string $name The model definition name.
-     * @param array $attr The model attributes.
-     * @param bool $save Are we saving, or just creating an instance?
+     * @param array  $attr The model attributes.
+     * @param bool   $save Are we saving, or just creating an instance?
      *
      * @return object
      */
@@ -189,7 +189,7 @@ class FactoryMuffin
     /**
      * Make an instance of a class.
      *
-     * @param string $class The model class name.
+     * @param string        $class The model class name.
      * @param callable|null $maker The maker callable.
      *
      * @throws \League\FactoryMuffin\Exceptions\ModelNotFoundException
@@ -239,7 +239,7 @@ class FactoryMuffin
      * This does not save it in the database. Use create for that.
      *
      * @param string $name The model definition name.
-     * @param array $attr The model attributes.
+     * @param array  $attr The model attributes.
      *
      * @return object
      */
@@ -256,7 +256,7 @@ class FactoryMuffin
      * Generate and set the model attributes.
      *
      * @param object $model The model instance.
-     * @param array $attr The model attributes.
+     * @param array  $attr  The model attributes.
      *
      * @return void
      */
@@ -265,7 +265,7 @@ class FactoryMuffin
         foreach ($attr as $key => $kind) {
             $value = $this->generatorFactory->generate($kind, $model, $this);
 
-            $setter = 'set' . $this->camelize($key);
+            $setter = 'set'.$this->camelize($key);
 
             // check if there is a setter and use it instead
             if (method_exists($model, $setter)) {
@@ -314,7 +314,7 @@ class FactoryMuffin
 
         if (strpos($name, ':') !== false) {
             $group = current(explode(':', $name));
-            $class = str_replace($group . ':', '', $name);
+            $class = str_replace($group.':', '', $name);
             $this->definitions[$name] = clone $this->getDefinition($class);
             $this->definitions[$name]->setGroup($group);
         } else {
@@ -339,7 +339,7 @@ class FactoryMuffin
      */
     public function loadFactories($paths)
     {
-        foreach ((array)$paths as $path) {
+        foreach ((array) $paths as $path) {
             if (!is_dir($path)) {
                 throw new DirectoryNotFoundException($path);
             }
@@ -373,11 +373,12 @@ class FactoryMuffin
     }
 
     /**
-     * Translates a string with underscores
-     * into camel case (e.g. first_name -> firstName).
+     * Camelize string
+     * 
+     * Transforms a string to camel case (e.g. first_name -> firstName).
      *
-     * @param string $str String in underscore format
-     * @param bool $capitaliseFirstChar If true, capitalise the first char in $str
+     * @param string $str                 String in underscore format
+     * @param bool   $capitaliseFirstChar If true, capitalise the first char in $str
      *
      * @return string $str translated into camel caps
      */

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -373,8 +373,8 @@ class FactoryMuffin
     }
 
     /**
-     * Camelize string
-     * 
+     * Camelize string.
+     *
      * Transforms a string to camel case (e.g. first_name -> firstName).
      *
      * @param string $str                 String in underscore format

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -265,7 +265,7 @@ class FactoryMuffin
         foreach ($attr as $key => $kind) {
             $value = $this->generatorFactory->generate($kind, $model, $this);
 
-            $setter = 'set'.$this->camelize($key);
+            $setter = 'set'.$this->camelize($key, true);
 
             // check if there is a setter and use it instead
             if (method_exists($model, $setter)) {

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -383,7 +383,7 @@ class FactoryMuffin
      */
     public function camelize($str)
     {
-        return preg_replace_callback('/_([a-z])/', function ($c) {
+        return preg_replace_callback('/_([a-z0-9])/', function ($c) {
             return strtoupper($c[1]);
         }, $str);
     }

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -265,7 +265,7 @@ class FactoryMuffin
         foreach ($attr as $key => $kind) {
             $value = $this->generatorFactory->generate($kind, $model, $this);
 
-            $setter = 'set'.$this->camelize($key, true);
+            $setter = 'set'.ucfirst($this->camelize($key));
 
             // check if there is a setter and use it instead
             if (method_exists($model, $setter)) {
@@ -378,16 +378,11 @@ class FactoryMuffin
      * Transforms a string to camel case (e.g. first_name -> firstName).
      *
      * @param string $str                 String in underscore format
-     * @param bool   $capitaliseFirstChar If true, capitalise the first char in $str
      *
      * @return string $str translated into camel caps
      */
-    public function camelize($str, $capitaliseFirstChar = false)
+    public function camelize($str)
     {
-        if ($capitaliseFirstChar) {
-            $str[0] = strtoupper($str[0]);
-        }
-
         return preg_replace_callback('/_([a-z])/', function ($c) {
             return strtoupper($c[1]);
         }, $str);

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -121,6 +121,9 @@ class FactoryMuffinTest extends AbstractTestCase
 
         $var = static::$fm->camelize('foo_bar_bar');
         $this->assertSame('fooBarBar', $var);
+
+        $var = static::$fm->camelize('foo_bar2');
+        $this->assertSame('fooBar2', $var);
     }
 }
 

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -111,7 +111,8 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertSame('Jack Sparrow', $obj->getName());
     }
 
-    public function testCamelization(){
+    public function testCamelization()
+    {
         $var = static::$fm->camelize('foo_bar');
         $this->assertSame('fooBar', $var);
 
@@ -231,11 +232,13 @@ class SetterTestModelWithSetter
 {
     private $name;
 
-    public function setName($name){
+    public function setName($name)
+    {
         $this->name = $name;
     }
 
-    public function getName(){
+    public function getName()
+    {
         return $this->name;
     }
 }

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -104,6 +104,26 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertInstanceOf('ModelWithStaticMethodFactory', $obj->data['object']);
         $this->assertFalse($obj->data['saved']);
     }
+
+    public function testSetAttributeUsingSetter()
+    {
+        $obj = static::$fm->instance('SetterTestModelWithSetter');
+        $this->assertSame('Jack Sparrow', $obj->getName());
+    }
+
+    public function testCamelization(){
+        $var = static::$fm->camelize('foo_bar');
+        $this->assertSame('fooBar', $var);
+
+        $var = static::$fm->camelize('foo');
+        $this->assertSame('foo', $var);
+
+        $var = static::$fm->camelize('foo_bar_bar');
+        $this->assertSame('fooBarBar', $var);
+
+        $var = static::$fm->camelize('foo_bar', true);
+        $this->assertSame('FooBar', $var);
+    }
 }
 
 class MainModelStub
@@ -204,5 +224,18 @@ class ModelWithStaticMethodFactory
     public function save()
     {
         return true;
+    }
+}
+
+class SetterTestModelWithSetter
+{
+    private $name;
+
+    public function setName($name){
+        $this->name = $name;
+    }
+
+    public function getName(){
+        return $this->name;
     }
 }

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -121,9 +121,6 @@ class FactoryMuffinTest extends AbstractTestCase
 
         $var = static::$fm->camelize('foo_bar_bar');
         $this->assertSame('fooBarBar', $var);
-
-        $var = static::$fm->camelize('foo_bar', true);
-        $this->assertSame('FooBar', $var);
     }
 }
 

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -63,3 +63,7 @@ $fm->define('ModelWithStaticMethodFactory')->setDefinitions([
         return compact('object', 'saved');
     },
 ]);
+
+$fm->define('SetterTestModelWithSetter')->setDefinitions([
+    'name' => 'Jack Sparrow'
+]);

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -65,5 +65,5 @@ $fm->define('ModelWithStaticMethodFactory')->setDefinitions([
 ]);
 
 $fm->define('SetterTestModelWithSetter')->setDefinitions([
-    'name' => 'Jack Sparrow'
+    'name' => 'Jack Sparrow',
 ]);


### PR DESCRIPTION
Some model attributes needs to be set through setter methods, but FactoryMuffin only sets the attributes directly. This fix checks for the presence of a setter method on the model and calls it instead. 
I also included a camelize function. It could possibly be refactored to another class.