### PR TITLE
Adds support for setting model attributes through setters

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -263,7 +263,16 @@ class FactoryMuffin
     protected function generate($model, array $attr = [])
     {
         foreach ($attr as $key => $kind) {
-            $model->$key = $this->generatorFactory->generate($kind, $model, $this);
+            $value = $this->generatorFactory->generate($kind, $model, $this);
+
+            $setter = 'set'.ucfirst(self::camelize($key));
+
+            // check if there is a setter and use it instead
+            if (method_exists($model, $setter)) {
+                $model->$setter($value);
+            } else {
+                $model->$key = $value;
+            }
         }
     }
 
@@ -361,5 +370,21 @@ class FactoryMuffin
         foreach ($files as $file) {
             require $file->getPathName();
         }
+    }
+
+    /**
+     * Camelize string.
+     *
+     * Transforms a string to camel case (e.g. first_name -> firstName).
+     *
+     * @param string $str String in underscore format.
+     *
+     * @return string
+     */
+    public static function camelize($str)
+    {
+        return preg_replace_callback('/_([a-z0-9])/', function ($c) {
+            return strtoupper($c[1]);
+        }, $str);
     }
 }

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -11,6 +11,7 @@
  */
 
 use League\FactoryMuffin\Exceptions\DefinitionNotFoundException;
+use League\FactoryMuffin\FactoryMuffin;
 
 /**
  * This is factory muffin test class.
@@ -103,6 +104,24 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertSame('just a string', $obj->string);
         $this->assertInstanceOf('ModelWithStaticMethodFactory', $obj->data['object']);
         $this->assertFalse($obj->data['saved']);
+    }
+
+    public function testSetAttributeUsingSetter()
+    {
+        $obj = static::$fm->instance('SetterTestModelWithSetter');
+        $this->assertSame('Jack Sparrow', $obj->getName());
+    }
+
+    public function testCamelization()
+    {
+        $var = FactoryMuffin::camelize('foo_bar');
+        $this->assertSame('fooBar', $var);
+
+        $var = FactoryMuffin::camelize('foo');
+        $this->assertSame('foo', $var);
+
+        $var = FactoryMuffin::camelize('foo_bar2_bar');
+        $this->assertSame('fooBar2Bar', $var);
     }
 }
 
@@ -204,5 +223,20 @@ class ModelWithStaticMethodFactory
     public function save()
     {
         return true;
+    }
+}
+
+class SetterTestModelWithSetter
+{
+    private $name;
+
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
     }
 }

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -63,3 +63,7 @@ $fm->define('ModelWithStaticMethodFactory')->setDefinitions([
         return compact('object', 'saved');
     },
 ]);
+
+$fm->define('SetterTestModelWithSetter')->setDefinitions([
+    'name' => 'Jack Sparrow',
+]);


### PR DESCRIPTION
Some model attributes needs to be set through setter methods, but
FactoryMuffin only sets the attributes directly. This fix checks for the
presence of a setter method on the model and calls it instead. I also
includes a camelize function.