### PR TITLE
Add detection for non public setter methods

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -19,6 +19,7 @@ use League\FactoryMuffin\Exceptions\ModelNotFoundException;
 use League\FactoryMuffin\Generators\GeneratorFactory;
 use RecursiveDirectoryIterator;
 use RecursiveIteratorIterator;
+use ReflectionMethod;
 use RegexIterator;
 
 /**
@@ -268,7 +269,7 @@ class FactoryMuffin
             $setter = 'set'.ucfirst(static::camelize($key));
 
             // check if there is a setter and use it instead
-            if (method_exists($model, $setter)) {
+            if (method_exists($model, $setter) && (new ReflectionMethod($model, $setter))->isPublic()) {
                 $model->$setter($value);
             } else {
                 $model->$key = $value;

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -112,6 +112,12 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertSame('Jack Sparrow', $obj->getName());
     }
 
+    public function testCanDetectNonPublicSetters()
+    {
+        $obj = static::$fm->instance('SetterTestModelWithNonPublicSetter');
+        $this->assertSame('Jack Sparrow', $obj->getName());
+    }
+
     public function testCamelization()
     {
         $var = FactoryMuffin::camelize('foo_bar');
@@ -231,6 +237,30 @@ class SetterTestModelWithSetter
     private $name;
 
     public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+class SetterTestModelWithNonPublicSetter
+{
+    private $name;
+
+    public function __set($key, $value)
+    {
+        if ($key === 'name') {
+            $this->setName($value);
+        } else {
+            $this->$key = $value;
+        }
+    }
+
+    private function setName($name)
     {
         $this->name = $name;
     }

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -67,3 +67,7 @@ $fm->define('ModelWithStaticMethodFactory')->setDefinitions([
 $fm->define('SetterTestModelWithSetter')->setDefinitions([
     'name' => 'Jack Sparrow',
 ]);
+
+$fm->define('SetterTestModelWithNonPublicSetter')->setDefinitions([
+    'name' => 'Jack Sparrow',
+]);


### PR DESCRIPTION
FactoryMuffin::generate does currently try to access protected or private setter methods independent of the visibility of the method.