### PR TITLE
DataMapper support with Doctrine tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
     "require-dev": {
         "illuminate/database": "5.0.*|5.1.*",
         "league/factory-muffin-faker": "^1.0@dev",
-        "phpunit/phpunit": "^4.8|^5.0"
+        "phpunit/phpunit": "^4.8|^5.0",
+        "doctrine/orm": "~2.5.0"
     },
     "replace": {
         "zizaco/factory-muff": "self.version"
@@ -37,7 +38,10 @@
     "autoload-dev": {
         "classmap": [
             "tests/AbstractTestCase.php"
-        ]
+        ],
+        "psr-4": {
+            "League\\FactoryMuffin\\Test\\": "tests/entities/"
+        }
     },
     "config": {
         "preferred-install": "dist"

--- a/src/Exceptions/DeletingFailedException.php
+++ b/src/Exceptions/DeletingFailedException.php
@@ -50,7 +50,6 @@ class DeletingFailedException extends Exception
             $count = count($exceptions);
             $problems = $this->plural('problem', $count);
             $message = "We encountered $count $problems while trying to delete the saved models.";
-            $message .= "\r\nIncluding: " . $exceptions[0]->getMessage();
         }
 
         parent::__construct($message);

--- a/src/Exceptions/DeletingFailedException.php
+++ b/src/Exceptions/DeletingFailedException.php
@@ -50,6 +50,7 @@ class DeletingFailedException extends Exception
             $count = count($exceptions);
             $problems = $this->plural('problem', $count);
             $message = "We encountered $count $problems while trying to delete the saved models.";
+            $message .= "\r\nIncluding: " . $exceptions[0]->getMessage();
         }
 
         parent::__construct($message);

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -54,8 +54,8 @@ class EntityGenerator implements GeneratorInterface
     /**
      * Create a new factory generator instance.
      *
-     * @param string $kind The kind of attribute.
-     * @param object $model The model instance.
+     * @param string                              $kind          The kind of attribute.
+     * @param object                              $model         The model instance.
      * @param \League\FactoryMuffin\FactoryMuffin $factoryMuffin The factory muffin instance.
      *
      * @return void

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -54,9 +54,11 @@ class EntityGenerator implements GeneratorInterface
     /**
      * Create a new factory generator instance.
      *
-     * @param string                              $kind          The kind of attribute.
-     * @param object                              $model         The model instance.
+     * @param string $kind The kind of attribute.
+     * @param object $model The model instance.
      * @param \League\FactoryMuffin\FactoryMuffin $factoryMuffin The factory muffin instance.
+     *
+     * @return void
      */
     public function __construct($kind, $model, FactoryMuffin $factoryMuffin)
     {

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Factory Muffin.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ * (c) Scott Robertson <scottymeuk@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FactoryMuffin\Generators;
+
+use League\FactoryMuffin\FactoryMuffin;
+
+/**
+ * This is the entity generator class.
+ *
+ * The entity generator can be useful for setting up relationships between
+ * models. The entity generator will create and return the generated model.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ * @author Scott Robertson <scottymeuk@gmail.com>
+ * @author Michael Bodnarchuk <davert@codeception.com>
+ */
+class EntityGenerator implements GeneratorInterface
+{
+    /**
+     * Definition prefix to match this generator
+     */
+    const PREFIX = 'entity|';
+    /**
+     * The kind of attribute that will be generated.
+     *
+     * @var string
+     */
+    private $kind;
+
+    /**
+     * The model instance.
+     *
+     * @var object
+     */
+    private $model;
+
+    /**
+     * The factory muffin instance.
+     *
+     * @var \League\FactoryMuffin\FactoryMuffin
+     */
+    private $factoryMuffin;
+
+    /**
+     * Create a new factory generator instance.
+     *
+     * @param string $kind The kind of attribute.
+     * @param object $model The model instance.
+     * @param \League\FactoryMuffin\FactoryMuffin $factoryMuffin The factory muffin instance.
+     *
+     */
+    public function __construct($kind, $model, FactoryMuffin $factoryMuffin)
+    {
+        $this->kind = $kind;
+        $this->model = $model;
+        $this->factoryMuffin = $factoryMuffin;
+    }
+
+    /**
+     * Generate, and return the attribute.
+     *
+     * The value returned is the id of the generated model, if applicable.
+     *
+     * @return int|null
+     */
+    public function generate()
+    {
+        $name = substr($this->kind, strlen(static::PREFIX));
+
+        return $this->factory($name);
+    }
+
+    /**
+     * Create an instance of the model.
+     *
+     * This model will be automatically saved to the database if the model we
+     * are generating it for has been saved (the create function was used).
+     *
+     * @param string $name The model definition name.
+     *
+     * @return object
+     */
+    private function factory($name)
+    {
+        if ($this->factoryMuffin->isPendingOrSaved($this->model)) {
+            return $this->factoryMuffin->create($name);
+        }
+
+        return $this->factoryMuffin->instance($name);
+    }
+
+}

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -24,12 +24,8 @@ use League\FactoryMuffin\FactoryMuffin;
  * @author Scott Robertson <scottymeuk@gmail.com>
  * @author Michael Bodnarchuk <davert@codeception.com>
  */
-class EntityGenerator implements GeneratorInterface
+class EntityGenerator implements GeneratorInterface, PrefixInterface
 {
-    /**
-     * Definition prefix to match this generator.
-     */
-    const PREFIX = 'entity|';
     /**
      * The kind of attribute that will be generated.
      *
@@ -76,7 +72,7 @@ class EntityGenerator implements GeneratorInterface
      */
     public function generate()
     {
-        $name = substr($this->kind, strlen(static::PREFIX));
+        $name = substr($this->kind, strlen(static::getPrefix()));
 
         return $this->factory($name);
     }
@@ -98,5 +94,15 @@ class EntityGenerator implements GeneratorInterface
         }
 
         return $this->factoryMuffin->instance($name);
+    }
+
+    /**
+     * Return the prefix for current generator
+     *
+     * @return string
+     */
+    public static function getPrefix()
+    {
+        return 'entity|';
     }
 }

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -27,7 +27,7 @@ use League\FactoryMuffin\FactoryMuffin;
 class EntityGenerator implements GeneratorInterface
 {
     /**
-     * Definition prefix to match this generator
+     * Definition prefix to match this generator.
      */
     const PREFIX = 'entity|';
     /**
@@ -54,10 +54,9 @@ class EntityGenerator implements GeneratorInterface
     /**
      * Create a new factory generator instance.
      *
-     * @param string $kind The kind of attribute.
-     * @param object $model The model instance.
+     * @param string                              $kind          The kind of attribute.
+     * @param object                              $model         The model instance.
      * @param \League\FactoryMuffin\FactoryMuffin $factoryMuffin The factory muffin instance.
-     *
      */
     public function __construct($kind, $model, FactoryMuffin $factoryMuffin)
     {
@@ -98,5 +97,4 @@ class EntityGenerator implements GeneratorInterface
 
         return $this->factoryMuffin->instance($name);
     }
-
 }

--- a/src/Generators/EntityGenerator.php
+++ b/src/Generators/EntityGenerator.php
@@ -97,7 +97,7 @@ class EntityGenerator implements GeneratorInterface, PrefixInterface
     }
 
     /**
-     * Return the prefix for current generator
+     * Return the prefix for current generator.
      *
      * @return string
      */

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -78,7 +78,7 @@ class FactoryGenerator extends EntityGenerator
     }
 
     /**
-     * Return the prefix for current generator
+     * Return the prefix for current generator.
      *
      * @return string
      */

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -25,8 +25,6 @@ namespace League\FactoryMuffin\Generators;
  */
 class FactoryGenerator extends EntityGenerator
 {
-    const PREFIX = 'factory|';
-
     /**
      * Generate, and return the attribute.
      *
@@ -77,5 +75,15 @@ class FactoryGenerator extends EntityGenerator
                 return $model->$property;
             }
         }
+    }
+
+    /**
+     * Return the prefix for current generator
+     *
+     * @return string
+     */
+    public static function getPrefix()
+    {
+        return 'factory|';
     }
 }

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -12,8 +12,6 @@
 
 namespace League\FactoryMuffin\Generators;
 
-use League\FactoryMuffin\FactoryMuffin;
-
 /**
  * This is the factory generator class.
  *
@@ -23,29 +21,11 @@ use League\FactoryMuffin\FactoryMuffin;
  *
  * @author Graham Campbell <graham@alt-three.com>
  * @author Scott Robertson <scottymeuk@gmail.com>
+ * @author Michael Bodnarchuk <davert@codeception.com>
  */
-class FactoryGenerator implements GeneratorInterface
+class FactoryGenerator extends EntityGenerator
 {
-    /**
-     * The kind of attribute that will be generated.
-     *
-     * @var string
-     */
-    private $kind;
-
-    /**
-     * The model instance.
-     *
-     * @var object
-     */
-    private $model;
-
-    /**
-     * The factory muffin instance.
-     *
-     * @var \League\FactoryMuffin\FactoryMuffin
-     */
-    private $factoryMuffin;
+    const PREFIX = 'factory|';
 
     /**
      * Generate, and return the attribute.
@@ -62,22 +42,6 @@ class FactoryGenerator implements GeneratorInterface
     private static $properties = ['id', '_id'];
 
     /**
-     * Create a new factory generator instance.
-     *
-     * @param string                              $kind          The kind of attribute.
-     * @param object                              $model         The model instance.
-     * @param \League\FactoryMuffin\FactoryMuffin $factoryMuffin The factory muffin instance.
-     *
-     * @return void
-     */
-    public function __construct($kind, $model, FactoryMuffin $factoryMuffin)
-    {
-        $this->kind = $kind;
-        $this->model = $model;
-        $this->factoryMuffin = $factoryMuffin;
-    }
-
-    /**
      * Generate, and return the attribute.
      *
      * The value returned is the id of the generated model, if applicable.
@@ -86,30 +50,8 @@ class FactoryGenerator implements GeneratorInterface
      */
     public function generate()
     {
-        $name = substr($this->kind, 8);
-
-        $model = $this->factory($name);
-
+        $model = parent::generate();
         return $this->getId($model);
-    }
-
-    /**
-     * Create an instance of the model.
-     *
-     * This model will be automatically saved to the database if the model we
-     * are generating it for has been saved (the create function was used).
-     *
-     * @param string $name The model definition name.
-     *
-     * @return object
-     */
-    private function factory($name)
-    {
-        if ($this->factoryMuffin->isPendingOrSaved($this->model)) {
-            return $this->factoryMuffin->create($name);
-        }
-
-        return $this->factoryMuffin->instance($name);
     }
 
     /**
@@ -135,4 +77,5 @@ class FactoryGenerator implements GeneratorInterface
             }
         }
     }
+
 }

--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -51,6 +51,7 @@ class FactoryGenerator extends EntityGenerator
     public function generate()
     {
         $model = parent::generate();
+
         return $this->getId($model);
     }
 
@@ -77,5 +78,4 @@ class FactoryGenerator extends EntityGenerator
             }
         }
     }
-
 }

--- a/src/Generators/GeneratorFactory.php
+++ b/src/Generators/GeneratorFactory.php
@@ -57,11 +57,11 @@ class GeneratorFactory
             return new CallableGenerator($kind, $model, $factoryMuffin);
         }
 
-        if (is_string($kind) && strpos($kind, EntityGenerator::PREFIX) === 0) {
+        if (is_string($kind) && strpos($kind, EntityGenerator::getPrefix()) === 0) {
             return new EntityGenerator($kind, $model, $factoryMuffin);
         }
 
-        if (is_string($kind) && strpos($kind, FactoryGenerator::PREFIX) === 0) {
+        if (is_string($kind) && strpos($kind, FactoryGenerator::getPrefix()) === 0) {
             return new FactoryGenerator($kind, $model, $factoryMuffin);
         }
     }

--- a/src/Generators/GeneratorFactory.php
+++ b/src/Generators/GeneratorFactory.php
@@ -57,7 +57,11 @@ class GeneratorFactory
             return new CallableGenerator($kind, $model, $factoryMuffin);
         }
 
-        if (is_string($kind) && strpos($kind, 'factory|') !== false) {
+        if (is_string($kind) && strpos($kind, EntityGenerator::PREFIX) === 0) {
+            return new EntityGenerator($kind, $model, $factoryMuffin);
+        }
+
+        if (is_string($kind) && strpos($kind, FactoryGenerator::PREFIX) === 0) {
             return new FactoryGenerator($kind, $model, $factoryMuffin);
         }
     }

--- a/src/Generators/PrefixInterface.php
+++ b/src/Generators/PrefixInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace League\FactoryMuffin\Generators;
+
+/**
+ * Interface for generator that require prefix to be declared
+ *
+ * @author Michael Bodnarchuk <davert@codeception.com>
+ */
+interface PrefixInterface
+{
+    /**
+     * Return the prefix for current generator
+     *
+     * @return string
+     */
+    public static function getPrefix();
+}

--- a/src/Generators/PrefixInterface.php
+++ b/src/Generators/PrefixInterface.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace League\FactoryMuffin\Generators;
 
 /**
- * Interface for generator that require prefix to be declared
+ * Interface for generator that require prefix to be declared.
  *
  * @author Michael Bodnarchuk <davert@codeception.com>
  */
 interface PrefixInterface
 {
     /**
-     * Return the prefix for current generator
+     * Return the prefix for current generator.
      *
      * @return string
      */

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -53,7 +53,7 @@ class RepositoryStore extends ModelStore
      * @throws \League\FactoryMuffin\Exceptions\SaveMethodNotFoundException
      * @throws \League\FactoryMuffin\Exceptions\MethodNotFoundException
      *
-     * @return boolean
+     * @return bool
      */
     protected function save($model)
     {
@@ -74,7 +74,7 @@ class RepositoryStore extends ModelStore
      *
      * @throws MethodNotFoundException
      *
-     * @return boolean
+     * @return bool
      */
     protected function flush()
     {

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -25,14 +25,14 @@ use League\FactoryMuffin\Exceptions\SaveMethodNotFoundException;
 class RepositoryStore extends ModelStore
 {
     /**
-     * Methods to flush changes to storage
+     * Methods to flush changes to storage.
      *
      * @var string
      */
-    protected $flushMethod  = 'flush';
+    protected $flushMethod = 'flush';
 
     /**
-     * Instance of a class that performs flushes (EntityManager for Doctrine)
+     * Instance of a class that performs flushes (EntityManager for Doctrine).
      *
      * @var
      */
@@ -52,6 +52,7 @@ class RepositoryStore extends ModelStore
      *
      * @throws \League\FactoryMuffin\Exceptions\SaveMethodNotFoundException
      * @throws \League\FactoryMuffin\Exceptions\MethodNotFoundException
+     *
      * @return mixed
      */
     protected function save($model)
@@ -63,14 +64,16 @@ class RepositoryStore extends ModelStore
         }
         $this->storage->$method($model);
         $this->flush();
+
         return true;
     }
 
     /**
-     * Flushes changes to storage
+     * Flushes changes to storage.
+     *
+     * @throws MethodNotFoundException
      *
      * @return mixed
-     * @throws MethodNotFoundException
      */
     protected function flush()
     {
@@ -80,6 +83,7 @@ class RepositoryStore extends ModelStore
             throw new MethodNotFoundException(get_class($this->storage), $method, "Can't save: flush method not found");
         }
         $this->storage->$method();
+
         return true;
     }
 
@@ -101,6 +105,7 @@ class RepositoryStore extends ModelStore
         }
 
         $this->storage->$method($model);
+
         return true;
     }
 

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -1,0 +1,121 @@
+<?php
+
+/*
+ * This file is part of Factory Muffin.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ * (c) Scott Robertson <scottymeuk@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace League\FactoryMuffin;
+
+use League\FactoryMuffin\Exceptions\DeleteMethodNotFoundException;
+use League\FactoryMuffin\Exceptions\DeletingFailedException;
+use League\FactoryMuffin\Exceptions\MethodNotFoundException;
+use League\FactoryMuffin\Exceptions\SaveMethodNotFoundException;
+
+/**
+ * This is the model store class.
+ *
+ * @author Michael Bodnarchuk <davert@codeception.com>
+ */
+class RepositoryStore extends ModelStore
+{
+    /**
+     * Methods to flush changes to storage
+     *
+     * @var string
+     */
+    protected $flushMethod  = 'flush';
+
+    /**
+     * Instance of a class that performs flushes (EntityManager for Doctrine)
+     *
+     * @var
+     */
+    protected $storage;
+
+    public function __construct($storage)
+    {
+        $this->storage = $storage;
+        $this->saveMethod = 'persist';
+        $this->deleteMethod = 'remove';
+    }
+
+    /**
+     * Save our object to the db, and keep track of it.
+     *
+     * @param object $model The model instance.
+     *
+     * @throws \League\FactoryMuffin\Exceptions\SaveMethodNotFoundException
+     * @throws \League\FactoryMuffin\Exceptions\MethodNotFoundException
+     * @return mixed
+     */
+    protected function save($model)
+    {
+        $method = $this->saveMethod;
+
+        if (!method_exists($this->storage, $method)) {
+            throw new SaveMethodNotFoundException(get_class($this->storage), $method);
+        }
+        $this->storage->$method($model);
+        $this->flush();
+        return true;
+    }
+
+    /**
+     * Flushes changes to storage
+     *
+     * @return mixed
+     * @throws MethodNotFoundException
+     */
+    protected function flush()
+    {
+        $method = $this->flushMethod;
+
+        if (!method_exists($this->storage, $method)) {
+            throw new MethodNotFoundException(get_class($this->storage), $method, "Can't save: flush method not found");
+        }
+        $this->storage->$method();
+        return true;
+    }
+
+    /**
+     * Delete our object from the db.
+     *
+     * @param object $model The model instance.
+     *
+     * @throws \League\FactoryMuffin\Exceptions\DeleteMethodNotFoundException
+     *
+     * @return mixed
+     */
+    protected function delete($model)
+    {
+        $method = $this->deleteMethod;
+
+        if (!method_exists($this->storage, $method)) {
+            throw new DeleteMethodNotFoundException(get_class($this->storage), $method);
+        }
+
+        $this->storage->$method($model);
+        return true;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws DeletingFailedException
+     */
+    public function deleteSaved()
+    {
+        parent::deleteSaved();
+        try {
+            $this->storage->flush();
+        } catch (\Exception $e) {
+            throw new DeletingFailedException([$e]);
+        }
+    }
+}

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -53,7 +53,7 @@ class RepositoryStore extends ModelStore
      * @throws \League\FactoryMuffin\Exceptions\SaveMethodNotFoundException
      * @throws \League\FactoryMuffin\Exceptions\MethodNotFoundException
      *
-     * @return mixed
+     * @return boolean
      */
     protected function save($model)
     {
@@ -62,6 +62,7 @@ class RepositoryStore extends ModelStore
         if (!method_exists($this->storage, $method)) {
             throw new SaveMethodNotFoundException(get_class($this->storage), $method);
         }
+
         $this->storage->$method($model);
         $this->flush();
 
@@ -73,7 +74,7 @@ class RepositoryStore extends ModelStore
      *
      * @throws MethodNotFoundException
      *
-     * @return mixed
+     * @return boolean
      */
     protected function flush()
     {
@@ -82,6 +83,7 @@ class RepositoryStore extends ModelStore
         if (!method_exists($this->storage, $method)) {
             throw new MethodNotFoundException(get_class($this->storage), $method, "Can't save: flush method not found");
         }
+
         $this->storage->$method();
 
         return true;

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -110,13 +110,16 @@ class RepositoryStore extends ModelStore
     }
 
     /**
-     * {@inheritdoc}
+     * Delete all the saved models.
      *
-     * @throws DeletingFailedException
+     * @throws \League\FactoryMuffin\Exceptions\DeletingFailedException
+     *
+     * @return void
      */
     public function deleteSaved()
     {
         parent::deleteSaved();
+
         try {
             $this->storage->flush();
         } catch (\Exception $e) {

--- a/src/RepositoryStore.php
+++ b/src/RepositoryStore.php
@@ -34,7 +34,7 @@ class RepositoryStore extends ModelStore
     /**
      * Instance of a class that performs flushes (EntityManager for Doctrine).
      *
-     * @var
+     * @var object
      */
     protected $storage;
 
@@ -72,7 +72,7 @@ class RepositoryStore extends ModelStore
     /**
      * Flushes changes to storage.
      *
-     * @throws MethodNotFoundException
+     * @throws \League\FactoryMuffin\Exceptions\MethodNotFoundException
      *
      * @return bool
      */
@@ -96,7 +96,7 @@ class RepositoryStore extends ModelStore
      *
      * @throws \League\FactoryMuffin\Exceptions\DeleteMethodNotFoundException
      *
-     * @return mixed
+     * @return bool
      */
     protected function delete($model)
     {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -21,6 +21,9 @@ use League\FactoryMuffin\Faker\Facade as Faker;
  */
 abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
 {
+    /**
+     * @var FactoryMuffin
+     */
     protected static $fm;
 
     public static function setupBeforeClass()

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -35,7 +35,12 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
+        try {
+
         static::$fm->deleteSaved();
+        } catch (Exception $e) {
+
+        }
         static::$fm = new FactoryMuffin();
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -35,10 +35,7 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
 
     public static function tearDownAfterClass()
     {
-        try {
-            static::$fm->deleteSaved();
-        } catch (Exception $e) {
-        }
+        static::$fm->deleteSaved();
         static::$fm = new FactoryMuffin();
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -36,10 +36,8 @@ abstract class AbstractTestCase extends PHPUnit_Framework_TestCase
     public static function tearDownAfterClass()
     {
         try {
-
-        static::$fm->deleteSaved();
+            static::$fm->deleteSaved();
         } catch (Exception $e) {
-
         }
         static::$fm = new FactoryMuffin();
     }

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -17,14 +17,15 @@ use League\FactoryMuffin\Faker\Facade as Faker;
 use League\FactoryMuffin\RepositoryStore;
 
 /**
- * This is eloquent test class.
+ * This is doctrine test class.
  *
- * @author Graham Campbell <graham@alt-three.com>
+ * @author Michael Bodnarchuk <davert@codeception.com>
  */
 class DoctrineTest extends AbstractTestCase
 {
     const USER_ENTITY = 'League\FactoryMuffin\Test\User';
     const CAT_ENTITY = 'League\FactoryMuffin\Test\Cat';
+    
     /**
      * @var EntityManager
      */

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -1,0 +1,147 @@
+<?php
+/*
+ * This file is part of Factory Muffin.
+ *
+ * (c) Graham Campbell <graham@alt-three.com>
+ * (c) Scott Robertson <scottymeuk@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Doctrine\ORM\Tools\SchemaTool;
+use Doctrine\ORM\Tools\Setup;
+use Doctrine\ORM\EntityManager;
+use League\FactoryMuffin\FactoryMuffin;
+use League\FactoryMuffin\Faker\Facade as Faker;
+use League\FactoryMuffin\RepositoryStore;
+
+/**
+ * This is eloquent test class.
+ *
+ * @author Graham Campbell <graham@alt-three.com>
+ */
+class DoctrineTest extends AbstractTestCase
+{
+
+    const USER_ENTITY = 'League\FactoryMuffin\Test\User';
+    const CAT_ENTITY = 'League\FactoryMuffin\Test\Cat';
+    /**
+     * @var EntityManager
+     */
+    protected static $em;
+
+    public static function setupBeforeClass()
+    {
+        $dbParams = array(
+            'driver'   => 'pdo_mysql',
+            'dbname'   => 'doctrine_test',
+            'user' => 'root'
+        );
+        $entitiesPath = [__DIR__ . '/entities'];
+
+        $config = Setup::createAnnotationMetadataConfiguration($entitiesPath, true);
+
+        static::$em = EntityManager::create($dbParams, $config);
+        static::$fm = new FactoryMuffin(new RepositoryStore(static::$em));
+        $schemaTool = new SchemaTool(static::$em);
+        $classes = [
+            static::$em->getClassMetadata(self::USER_ENTITY),
+            static::$em->getClassMetadata(self::CAT_ENTITY)
+        ];
+        $schemaTool->dropSchema($classes);
+        $schemaTool->createSchema($classes);
+
+
+        static::$fm->define(self::USER_ENTITY)->setDefinitions([
+            'name'   => Faker::firstNameMale(),
+            'email'  => Faker::email(),
+        ]);
+
+        static::$fm->getDefinition(self::USER_ENTITY)->setCallback(function($model) {
+            static::$em->refresh($model);
+        });
+
+        static::$fm->define(self::CAT_ENTITY)->setDefinitions([
+            'name'    => Faker::firstNameFemale(),
+            'user' => 'entity|'.self::USER_ENTITY,
+        ]);
+
+        Faker::setLocale('en_GB');
+
+        static::$fm->seed(5, self::USER_ENTITY);
+        static::$fm->seed(50, self::CAT_ENTITY);
+    }
+
+    public static function tearDownAfterClass()
+    {
+        static::$fm->deleteSaved();
+        static::$fm = new FactoryMuffin();
+    }
+
+
+    public function testNumberOfCats()
+    {
+        $cats = [];
+        $users = static::$em->getRepository(self::USER_ENTITY)->findAll();
+
+        foreach ($users as $user) {
+            $userCats = $user->getCats();
+            foreach ($userCats as $cat) {
+                $cats[] = $cat;
+            }
+        }
+        $this->assertCount(50, $cats);
+        $this->assertInstanceOf(self::CAT_ENTITY, $cats[0]);
+    }
+
+    public function testNumberOfCatOwners()
+    {
+        $users = [];
+        $cats = static::$em->getRepository(self::CAT_ENTITY)->findAll();
+        foreach ($cats as $cat) {
+            $users[] = $cat->getUser();
+        }
+
+        $this->assertCount(50, $users);
+        $this->assertInstanceOf(self::USER_ENTITY, $users[0]);
+    }
+
+    public function testUserProperties()
+    {
+        $user = self::$em->find(self::USER_ENTITY, 1);
+
+        $this->assertGreaterThan(1, strlen($user->getName()));
+        $this->assertGreaterThan(5, strlen($user->getEmail()));
+        $this->assertContains('@', $user->getEmail());
+        $this->assertContains('.', $user->getEmail());
+    }
+
+    public function testCatProperties()
+    {
+        $cat = self::$em->find(self::CAT_ENTITY, 1);
+
+        $this->assertGreaterThan(1, strlen($cat->getName()));
+        $this->assertInstanceOf(self::USER_ENTITY, $cat->getUser());
+    }
+
+    public function testSavedObjects()
+    {
+        $reflection = new ReflectionClass(static::$fm);
+        $store = $reflection->getProperty('modelStore');
+        $store->setAccessible(true);
+        $value = $store->getValue(static::$fm);
+
+        // 50 cats + 50 corresponding users + 5 users without cats
+        $this->assertCount(105, $value->saved());
+        $this->assertCount(0, $value->pending());
+    }
+
+    public function testDeleteSaved()
+    {
+        $cat = self::$fm->create(self::CAT_ENTITY);
+        $user = $cat->getUser();
+        
+    }
+}
+

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -9,9 +9,9 @@
  * file that was distributed with this source code.
  */
 
+use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\ORM\Tools\Setup;
-use Doctrine\ORM\EntityManager;
 use League\FactoryMuffin\FactoryMuffin;
 use League\FactoryMuffin\Faker\Facade as Faker;
 use League\FactoryMuffin\RepositoryStore;
@@ -23,7 +23,6 @@ use League\FactoryMuffin\RepositoryStore;
  */
 class DoctrineTest extends AbstractTestCase
 {
-
     const USER_ENTITY = 'League\FactoryMuffin\Test\User';
     const CAT_ENTITY = 'League\FactoryMuffin\Test\Cat';
     /**
@@ -33,12 +32,12 @@ class DoctrineTest extends AbstractTestCase
 
     public static function setupBeforeClass()
     {
-        $dbParams = array(
+        $dbParams = [
             'driver'   => 'pdo_mysql',
             'dbname'   => 'doctrine_test',
-            'user' => 'root'
-        );
-        $entitiesPath = [__DIR__ . '/entities'];
+            'user'     => 'root',
+        ];
+        $entitiesPath = [__DIR__.'/entities'];
 
         $config = Setup::createAnnotationMetadataConfiguration($entitiesPath, true);
 
@@ -47,24 +46,23 @@ class DoctrineTest extends AbstractTestCase
         $schemaTool = new SchemaTool(static::$em);
         $classes = [
             static::$em->getClassMetadata(self::USER_ENTITY),
-            static::$em->getClassMetadata(self::CAT_ENTITY)
+            static::$em->getClassMetadata(self::CAT_ENTITY),
         ];
         $schemaTool->dropSchema($classes);
         $schemaTool->createSchema($classes);
-
 
         static::$fm->define(self::USER_ENTITY)->setDefinitions([
             'name'   => Faker::firstNameMale(),
             'email'  => Faker::email(),
         ]);
 
-        static::$fm->getDefinition(self::USER_ENTITY)->setCallback(function($model) {
+        static::$fm->getDefinition(self::USER_ENTITY)->setCallback(function ($model) {
             static::$em->refresh($model);
         });
 
         static::$fm->define(self::CAT_ENTITY)->setDefinitions([
             'name'    => Faker::firstNameFemale(),
-            'user' => 'entity|'.self::USER_ENTITY,
+            'user'    => 'entity|'.self::USER_ENTITY,
         ]);
 
         Faker::setLocale('en_GB');
@@ -78,7 +76,6 @@ class DoctrineTest extends AbstractTestCase
         static::$fm->deleteSaved();
         static::$fm = new FactoryMuffin();
     }
-
 
     public function testNumberOfCats()
     {
@@ -147,4 +144,3 @@ class DoctrineTest extends AbstractTestCase
         $this->assertCount(0, $users);
     }
 }
-

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -34,8 +34,7 @@ class DoctrineTest extends AbstractTestCase
     public static function setupBeforeClass()
     {
         $dbParams = [
-            'driver'   => 'pdo_sqlite',
-            'dbname'   => ':memory:',
+            'url'   => 'sqlite:///:memory:',
         ];
         $entitiesPath = [__DIR__.'/entities'];
 

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -34,7 +34,8 @@ class DoctrineTest extends AbstractTestCase
     public static function setupBeforeClass()
     {
         $dbParams = [
-            'url'   => 'sqlite:///:memory:',
+            'driver'   => 'pdo_sqlite',
+            'memory'   => true,
         ];
         $entitiesPath = [__DIR__.'/entities'];
 

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -33,9 +33,8 @@ class DoctrineTest extends AbstractTestCase
     public static function setupBeforeClass()
     {
         $dbParams = [
-            'driver'   => 'pdo_mysql',
-            'dbname'   => 'doctrine_test',
-            'user'     => 'root',
+            'driver'   => 'pdo_sqlite',
+            'dbname'   => 'memory'
         ];
         $entitiesPath = [__DIR__.'/entities'];
 

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -25,7 +25,7 @@ class DoctrineTest extends AbstractTestCase
 {
     const USER_ENTITY = 'League\FactoryMuffin\Test\User';
     const CAT_ENTITY = 'League\FactoryMuffin\Test\Cat';
-    
+
     /**
      * @var EntityManager
      */
@@ -35,7 +35,7 @@ class DoctrineTest extends AbstractTestCase
     {
         $dbParams = [
             'driver'   => 'pdo_sqlite',
-            'dbname'   => 'memory'
+            'dbname'   => ':memory:',
         ];
         $entitiesPath = [__DIR__.'/entities'];
 

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -37,9 +37,7 @@ class DoctrineTest extends AbstractTestCase
             'driver'   => 'pdo_sqlite',
             'memory'   => true,
         ];
-        $entitiesPath = [__DIR__.'/entities'];
-
-        $config = Setup::createAnnotationMetadataConfiguration($entitiesPath, true);
+        $config = Setup::createAnnotationMetadataConfiguration([__DIR__.'/entities'], true);
 
         static::$em = EntityManager::create($dbParams, $config);
         static::$fm = new FactoryMuffin(new RepositoryStore(static::$em));

--- a/tests/DoctrineTest.php
+++ b/tests/DoctrineTest.php
@@ -141,7 +141,10 @@ class DoctrineTest extends AbstractTestCase
     {
         $cat = self::$fm->create(self::CAT_ENTITY);
         $user = $cat->getUser();
-        
+        $this->assertInstanceOf(self::USER_ENTITY, $user);
+        static::tearDownAfterClass();
+        $users = static::$em->getRepository(self::USER_ENTITY)->findAll();
+        $this->assertCount(0, $users);
     }
 }
 

--- a/tests/entities/Cat.php
+++ b/tests/entities/Cat.php
@@ -1,0 +1,64 @@
+<?php
+namespace League\FactoryMuffin\Test;
+
+/**
+ * @Entity
+ * @Table(name="cats")
+ */
+class Cat
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+
+    /** @Column(length=140) */
+    private $name;
+
+    /**
+     * @ManyToOne(targetEntity="League\FactoryMuffin\Test\User", inversedBy="cats")
+     */
+    private $user;
+
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getUser()
+    {
+        return $this->user;
+    }
+
+    /**
+     * @param mixed $user
+     */
+    public function setUser($user)
+    {
+        $this->user = $user;
+    }
+
+}

--- a/tests/entities/Cat.php
+++ b/tests/entities/Cat.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace League\FactoryMuffin\Test;
 
 /**
@@ -60,5 +61,4 @@ class Cat
     {
         $this->user = $user;
     }
-
 }

--- a/tests/entities/User.php
+++ b/tests/entities/User.php
@@ -1,0 +1,83 @@
+<?php
+namespace League\FactoryMuffin\Test;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ * @Table(name="users")
+ */
+class User
+{
+    /**
+     * @Id @Column(type="integer")
+     * @GeneratedValue
+     */
+    private $id;
+    /**
+     * @Column(length=140)
+     */
+    private $name;
+
+    /**
+     * @Column(length=140)
+     */
+    private $email;
+
+    /**
+     * @OneToMany(targetEntity="League\FactoryMuffin\Test\Cat", mappedBy="user", cascade={"persist", "remove"}, orphanRemoval=true)
+     */
+    private $cats;
+
+    public function __construct()
+    {
+        $this->cats = new ArrayCollection();
+    }
+    /**
+     * @return mixed
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param mixed $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getEmail()
+    {
+        return $this->email;
+    }
+
+    /**
+     * @param mixed $email
+     */
+    public function setEmail($email)
+    {
+        $this->email = $email;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCats()
+    {
+        return $this->cats;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getId()
+    {
+        return $this->id;
+    }
+}

--- a/tests/entities/User.php
+++ b/tests/entities/User.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace League\FactoryMuffin\Test;
 
 use Doctrine\Common\Collections\ArrayCollection;
@@ -33,6 +34,7 @@ class User
     {
         $this->cats = new ArrayCollection();
     }
+
     /**
      * @return mixed
      */


### PR DESCRIPTION
Now you can use have FactoryMuffin to work with DataMapper pattern, especially with Doctrine. 
To have FactoryMuffin to be initialized with Doctine you should use `RepositoryStore` instead of `ModelStore` class:

```php
$em = EntityManager::create($dbParams, $config);
$fm = new FactoryMuffin(new RepositoryStore($em));
```

Unlike model store you can't use `factory` prefix to create associated models. `factory` creation method is supported to create a record and recturn its id, while Doctrine expects to receive a complete entity into association. That's why you should use `entity` to get a record into association

```php
'user_id' => 'factory|User', // to receive id of a record
// vs
'user' => 'entity|User', // to receive a record
```

Also Doctrine added as dev dependency and tests for it added.