### PR TITLE
Get all defined definitions

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -251,7 +251,7 @@ class FactoryMuffin
     }
 
     /**
-     * Get all defined model definitions
+     * Get all defined model definitions.
      *
      * @return \League\FactoryMuffin\Definition[]
      */

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -251,6 +251,16 @@ class FactoryMuffin
     }
 
     /**
+     * Get all defined model definitions
+     *
+     * @return \League\FactoryMuffin\Definition[]
+     */
+    public function getDefinitions()
+    {
+        return $this->definitions;
+    }
+
+    /**
      * Get a model definition.
      *
      * @param string $name The model definition name.

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -34,6 +34,13 @@ class DefinitionTest extends AbstractTestCase
         $this->assertContains('@', $user->email);
     }
 
+    public function testGetDefinitions()
+    {
+        $definitions = static::$fm->getDefinitions();
+
+        $this->assertCount(39, $definitions);
+    }
+
     public function testBasicDefinitionFunctions()
     {
         $definition = static::$fm->getDefinition('AttributeDefinitionsStub');


### PR DESCRIPTION
This PR adds a small convenience method in order to get all defined model definitions. 
This is especially useful if you want to load different sets of factories based on the context.