### PR TITLE
Add support field 'Id' as PK

### DIFF
--- a/src/Generators/FactoryGenerator.php
+++ b/src/Generators/FactoryGenerator.php
@@ -37,7 +37,7 @@ class FactoryGenerator extends EntityGenerator
      *
      * @var string[]
      */
-    private static $properties = ['id', '_id'];
+    private static $properties = ['id', '_id', 'Id'];
 
     /**
      * Generate, and return the attribute.


### PR DESCRIPTION
We have all the fields in the database begins with a capital letter, that it will help me to work with Yii2 models in our project. This change should not break backward compatibility.