### PR TITLE
Rename reference to upstream lib in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Factory Muffin 3.0
 
 The goal of this package is to enable the rapid creation of objects for the purpose of testing.
 
-It's basically a "[factory\_girl](https://github.com/thoughtbot/factory_girl)", simplified for use with PHP.
+It's basically a "[factory\_bot](https://github.com/thoughtbot/factory_bot)", simplified for use with PHP.
 
 
 ## Installing


### PR DESCRIPTION
factory_girl has been renamed to factory_bot. Lets reference the new name.