### PR TITLE
Implement the in memory store

### DIFF
--- a/src/Stores/InMemoryStore.php
+++ b/src/Stores/InMemoryStore.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace League\FactoryMuffin\Stores;
+
+/**
+ * This is the model store class.
+ *
+ * Useful if you want fixtures but don't actually have a persistence layer.
+ *
+ * @author Maarten Bicknese <maarten.bicknese@gmail.com>
+ */
+class InMemoryStore extends AbstractStore implements StoreInterface
+{
+    /**
+     * Save our object to the db, and keep track of it.
+     *
+     * @param object $model The model instance.
+     *
+     * @return bool
+     */
+    protected function save($model)
+    {
+        return true;
+    }
+
+    /**
+     * Delete our object from the db.
+     *
+     * @param object $model The model instance.
+     *
+     * @return mixed
+     */
+    protected function delete($model)
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
In some cases it is nice to be able to use your existing setup, without actually needing to persist your entities. e.g. When you run a unit test and simply want to re-use your existing factories.

By instantiating the muffin with the in memory store, one can simply create new fixtures.