### PR TITLE
Change factory loader to not filter all paths with hidden directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ You can define model factories using the `define` function. You may call it like
 
 You can also define multiple different model definitions for your models. You can do this by prefixing the model class name with your "group" followed by a colon. This results in you defining your model like this: `$fm->define('myGroup:Fully\Qualifed\ModelName')->addDefinitions('bar', 'baz')`. You don't have to entirely define your model here because we will first look for a definition without the group prefix, then apply your group definition on top of that definition, overriding attribute definitions where required.
 
-We have provided a nifty way for you to do this in your tests. PHPUnit provides a `setupBeforeClass` function. Within that function you can call `$fm->loadFactories(__DIR__ . '/factories');`, and it will include all files in the factories folder. Within those php files, you can put your definitions (all your code that calls the define function). The `loadFactories` function will throw a `League\FactoryMuffin\Exceptions\DirectoryNotFoundException` exception if the directory you're loading is not found.
+We have provided a nifty way for you to do this in your tests. PHPUnit provides a `setupBeforeClass` function. Within that function you can call `$fm->loadFactories(__DIR__ . '/factories');`, and it will include all files in the factories folder. Within those PHP files, you can put your definitions (all your code that calls the define function).
+ 
+The `loadFactories` function will recurse through all sub-folders of the path you specify when searching for factory files, except for hidden folders (i.e. starting with a .) which will be ignored. It will also throw a `League\FactoryMuffin\Exceptions\DirectoryNotFoundException` exception if the factories directory you specify is not found. 
 
 ### Creation/Instantiation Callbacks
 

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -83,7 +83,7 @@ class FactoryMuffin
     {
         $seeds = [];
 
-        for ($i = 0; $i < $times; ++$i) {
+        for ($i = 0; $i < $times; $i++) {
             $seeds[] = $this->create($name, $attr);
         }
 
@@ -341,7 +341,8 @@ class FactoryMuffin
     }
 
     /**
-     * Load all the files in a directory.
+     * Load all the files in a directory or sub-directory.
+     * Files that start with a . or do not have a .php extension are ignored.
      *
      * Each required file will have this instance available as "$fm".
      *
@@ -353,11 +354,17 @@ class FactoryMuffin
     {
         $directory = new RecursiveDirectoryIterator($path);
         $iterator = new RecursiveIteratorIterator($directory);
-        $files = new RegexIterator($iterator, '/^[^\.](?:(?!\/\.).)+?\.php$/i');
+        $files = new RegexIterator($iterator, '/^.+\.php$/i');
 
         $fm = $this;
 
         foreach ($files as $file) {
+            // Ignore factories in hidden subdirectories (e.g. '.AppleDouble'), to stop invalid files being loaded.
+            // See: https://github.com/thephpleague/factory-muffin/issues/414
+            if ('.' === substr($file->getPathInfo()->getFilename(), 0, 1)) {
+                continue;
+            }
+
             require $file->getPathName();
         }
     }

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -342,8 +342,8 @@ class FactoryMuffin
 
     /**
      * Load all the files in a directory or sub-directory.
-     * Files that start with a . or do not have a .php extension are ignored.
      *
+     * Files that start with a . or do not have a .php extension are ignored.
      * Each required file will have this instance available as "$fm".
      *
      * @param string $path The directory path to load.
@@ -359,8 +359,7 @@ class FactoryMuffin
         $fm = $this;
 
         foreach ($files as $file) {
-            // Ignore factories in hidden subdirectories (e.g. '.AppleDouble'), to stop invalid files being loaded.
-            // See: https://github.com/thephpleague/factory-muffin/issues/414
+            // Ignore factories in hidden subdirectories
             if ('.' === substr($file->getPathInfo()->getFilename(), 0, 1)) {
                 continue;
             }


### PR DESCRIPTION
This PR fixes an issue where FactoryMuffin will ignore loading factory definitions if they have a period anywhere in the absolute path to the _factories_ folder. This change disregards any periods in the actual absolute path to the factories folder for filtering purposes, but still filters out hidden subdirectories within the _factories_ folder when looking for factories.

For example, an absolute path of `/home/ci/.jenkins-slave/workspace/some_project/tests/_support/factories` passed to `FactoryMuffin->loadDirectory()` will be filtered out by the `RegexIterator` using the regex `'/^[^\.](?:(?!\/\.).)+?\.php$/i'`. This causes no factories to be loaded, despite having valid definitions in the _factories_ folder, and a `DefinitionNotFoundException` to be ultimately thrown by any tests requiring model definitions. 

The loader within this PR will still load factories from within `/home/ci/.jenkins-slave/workspace/some_project/tests/_support/factories` and `/home/ci/.jenkins-slave/workspace/some_project/tests/_support/factories/some/namespace` but not `/home/ci/.jenkins-slave/workspace/some_project/tests/_support/factories/.hidden/`.

I couldn't find a pure regex way to get to the above solution, so I reverted to an earlier regex that filters for .php extensions only and tweaked the loader `foreach()` loop to contain the additional directory filtering logic. This is a bit ugly but makes the filtering logic clear, especially when compared to a long regex, which will get complicated if it has to look for the n-1 directory, check if it has a period, and also work with both *nix(/) and Windows (\\) paths.

**Background**

We use FactoryMuffin within Codeception. The latter generates an absolute URL to the factories directory which is then passed to `FactoryMuffin::loadFactories()`. This is fine during local development, as there tends to not be hidden directories in the absolute path. During CI, however, this is a problem as there are often auto-generated directories like `.jenkins-slave` in the absolute path.

This issue was introduced in [this commit](https://github.com/thephpleague/factory-muffin/commit/a85c15703a1f88e81df4d22bb34ce935022a6838) as a fix for [this](https://github.com/thephpleague/factory-muffin/issues/414). It is likely the root cause for this issue [here](https://github.com/thephpleague/factory-muffin/issues/427), although no one has posted their paths there.

**Tests**

I haven't added any tests because this would likely require adding a mock filesystem but I'm happy to do this.