### PR TITLE
Possibly switch off automatic usage of model setters

### DIFF
--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -90,7 +90,7 @@ class FactoryMuffin
     }
 
     /**
-     * Get the boolean flag indicating usage of model inherent internal setter methods
+     * Get the boolean flag indicating usage of model inherent internal setter methods.
      *
      * @return bool
      */

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -55,6 +55,15 @@ class FactoryMuffin
     protected $factory;
 
     /**
+     * Do we want to allow usage of model setter methods
+     * inferred by name?
+     *
+     * @var bool
+     */
+    protected $useModelSetters;
+
+
+    /**
      * Create a new factory muffin instance.
      *
      * @param \League\FactoryMuffin\Stores\StoreInterface|null       $store   The store instance.
@@ -62,10 +71,33 @@ class FactoryMuffin
      *
      * @return void
      */
-    public function __construct(StoreInterface $store = null, GeneratorFactory $factory = null)
+    public function __construct(StoreInterface $store = null, GeneratorFactory $factory = null, bool $useModelSetters = true)
     {
         $this->store = $store ?: new ModelStore();
         $this->factory = $factory ?: new GeneratorFactory();
+        $this->useModelSetters = $useModelSetters;
+    }
+
+    /**
+     * Set the boolean flag indicating usage of model inherent internal setter methods
+     *
+     * @param bool use the model provided setter methods?
+     *
+     * @return void
+     */
+    public function setUseModelSetters($useModelSetters)
+    {
+        $this->useModelSetters = $useModelSetters;
+    }
+
+    /**
+     * Get the boolean flag indicating usage of model inherent internal setter methods
+     *
+     * @return bool
+     */
+    public function getUseModelSetters()
+    {
+        return $this->useModelSetters;
     }
 
     /**
@@ -242,7 +274,7 @@ class FactoryMuffin
             $setter = 'set'.ucfirst(static::camelize($key));
 
             // check if there is a setter and use it instead
-            if (method_exists($model, $setter) && is_callable([$model, $setter])) {
+            if ($this->useModelSetters && method_exists($model, $setter) && is_callable([$model, $setter])) {
                 $model->$setter($value);
             } else {
                 $model->$key = $value;

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -114,7 +114,7 @@ class FactoryMuffin
     {
         $seeds = [];
 
-        for ($i = 0; $i < $times; ++$i) {
+        for ($i = 0; $i < $times; $i++) {
             $seeds[] = $this->create($name, $attr);
         }
 

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -62,7 +62,6 @@ class FactoryMuffin
      */
     protected $useModelSetters;
 
-
     /**
      * Create a new factory muffin instance.
      *
@@ -79,7 +78,7 @@ class FactoryMuffin
     }
 
     /**
-     * Set the boolean flag indicating usage of model inherent internal setter methods
+     * Set the boolean flag indicating usage of model inherent internal setter methods.
      *
      * @param bool use the model provided setter methods?
      *

--- a/src/FactoryMuffin.php
+++ b/src/FactoryMuffin.php
@@ -67,10 +67,11 @@ class FactoryMuffin
      *
      * @param \League\FactoryMuffin\Stores\StoreInterface|null       $store   The store instance.
      * @param \League\FactoryMuffin\Generators\GeneratorFactory|null $factory The generator factory instance.
+     * @param bool $useModelSetters Allow/disallow usage of model setter methods.
      *
      * @return void
      */
-    public function __construct(StoreInterface $store = null, GeneratorFactory $factory = null, bool $useModelSetters = true)
+    public function __construct(StoreInterface $store = null, GeneratorFactory $factory = null, $useModelSetters = true)
     {
         $this->store = $store ?: new ModelStore();
         $this->factory = $factory ?: new GeneratorFactory();

--- a/tests/DefinitionTest.php
+++ b/tests/DefinitionTest.php
@@ -38,7 +38,7 @@ class DefinitionTest extends AbstractTestCase
     {
         $definitions = static::$fm->getDefinitions();
 
-        $this->assertCount(39, $definitions);
+        $this->assertCount(40, $definitions);
     }
 
     public function testBasicDefinitionFunctions()

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -288,7 +288,7 @@ class SetterTestNotUseModelSetters
 
     public function setName($name)
     {
-        $this->name = "we do not want to see this as name";
+        $this->name = 'we do not want to see this as name';
     }
 
     public function getName()

--- a/tests/FactoryMuffinTest.php
+++ b/tests/FactoryMuffinTest.php
@@ -119,6 +119,16 @@ class FactoryMuffinTest extends AbstractTestCase
         $this->assertSame('Jack Sparrow', $obj->getName());
     }
 
+    public function testDoNotUseModelSetter()
+    {
+        // setting use of model setters to false
+        static::$fm->setUseModelSetters(false);
+        $obj = static::$fm->instance('SetterTestNotUseModelSetters');
+        $this->assertSame('Jack Sparrow', $obj->getName());
+        // setting use of model setters to true again
+        static::$fm->setUseModelSetters(true);
+    }
+
     public function testCamelization()
     {
         $var = FactoryMuffin::camelize('foo_bar');
@@ -264,6 +274,21 @@ class SetterTestModelWithNonPublicSetter
     private function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+}
+
+class SetterTestNotUseModelSetters
+{
+    public $name;
+
+    public function setName($name)
+    {
+        $this->name = "we do not want to see this as name";
     }
 
     public function getName()

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -71,3 +71,8 @@ $fm->define('SetterTestModelWithSetter')->setDefinitions([
 $fm->define('SetterTestModelWithNonPublicSetter')->setDefinitions([
     'name' => 'Jack Sparrow',
 ]);
+
+
+$fm->define('SetterTestNotUseModelSetters')->setDefinitions([
+    'name' => 'Jack Sparrow',
+]);

--- a/tests/factories/main.php
+++ b/tests/factories/main.php
@@ -72,7 +72,6 @@ $fm->define('SetterTestModelWithNonPublicSetter')->setDefinitions([
     'name' => 'Jack Sparrow',
 ]);
 
-
 $fm->define('SetterTestNotUseModelSetters')->setDefinitions([
     'name' => 'Jack Sparrow',
 ]);


### PR DESCRIPTION
If a user wants to disable automatic detection and calling of model setter methods while generating this can be done by a call to `setUseModelSetters(false)` before creating model instances

