### PR TITLE
Support for Yii2 model validation errors

### DIFF
--- a/src/Stores/AbstractStore.php
+++ b/src/Stores/AbstractStore.php
@@ -63,6 +63,10 @@ abstract class AbstractStore
                 throw new SaveFailedException(get_class($model), $model->validationErrors);
             }
 
+            if (isset($model->errors) && is_array($model->errors)) {
+                throw new SaveFailedException(get_class($model), print_r($model->errors, 1));
+            }
+
             throw new SaveFailedException(get_class($model));
         }
 


### PR DESCRIPTION
Yii2 Framework provides a model validation using `rules` method. Error messages are saved to `errors` property in the model. 
Current version of `AbstractStore` checks only for `validationErrors` property but it's not enough. Every time error occurs we see "_We could not save the model_" without details.

So I added support for Yii2 validation errors.

P.S. Not quite sure about formatting errors as a string. It seems `print_r` fits well. 