### PR TITLE
Make setCallback() add to previous callbacks

### DIFF
--- a/src/Definition.php
+++ b/src/Definition.php
@@ -145,7 +145,15 @@ final class Definition
      */
     public function setCallback(callable $callback)
     {
-        $this->callback = $callback;
+        if ($this->callback) { // "stack" the callbacks so that any previous callbacks will also be called.
+            $oldCallback = $this->callback;
+            $this->callback = function ($model, $saved) use ($oldCallback, $callback) {
+                // If the old callback returns false, the whole thing should return false.
+                return $oldCallback($model, $saved) !== false && $callback($model, $saved) !== false;
+            };
+        } else {
+            $this->callback = $callback;
+        }
 
         return $this;
     }


### PR DESCRIPTION
setCallback() replaces previous callbacks making you have to repeat any logic in the "base case' definition callback if you have a callback on one of the groups.

See issue #472

A better solution may be to add a `addCallback` method instead of modifying `setCallback()`.