### PR TITLE
message-exception-passing

### DIFF
--- a/src/Stores/RepositoryStore.php
+++ b/src/Stores/RepositoryStore.php
@@ -136,7 +136,7 @@ class RepositoryStore extends AbstractStore implements StoreInterface
         try {
             $this->flush();
         } catch (Exception $e) {
-            throw new DeletingFailedException([$e]);
+            throw new DeletingFailedException([$e], $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
Providing a meaningfull error message when there is just one exception passed to DeletingFailedException.
The original error message doesn't give much details about the nature of the error. Passing the original error message would help folks debugging as it helped me 